### PR TITLE
chore: bump polars 0.51→0.53 and update all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,12 @@ path = "src/main.rs"
 
 [dependencies]
 # Data processing - columnar storage with lazy evaluation
-polars = { version = "0.53", features = [
+polars = { version = "0.54", features = [
   "parquet",
   "lazy",
   "dtype-full",
   "rank",
+  "strings",
 ] }
 
 # Parallelism - work-stealing scheduler

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Data processing - columnar storage with lazy evaluation
-polars = { version = "0.51", features = [
+polars = { version = "0.53", features = [
   "parquet",
   "lazy",
   "dtype-full",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ polars = { version = "0.53", features = [
 ] }
 
 # Parallelism - work-stealing scheduler
-rayon = "1.10"
+rayon = "1.12"
 
 # Serialization - zero-copy model loading
 rkyv = "0.8"
@@ -63,16 +63,16 @@ rkyv = "0.8"
 tdigest = "0.2"
 
 # Linear algebra - pure Rust, no C/Fortran linking
-faer = "0.23"
+faer = "0.24"
 
 # Safe transmutation for histogram entries
-bytemuck = { version = "1.19", features = ["derive"] }
+bytemuck = { version = "1.25", features = ["derive"] }
 
 # Fast hashing for target encoding maps
 rustc-hash = "2.1"
 
 # Random number generation for data splitting
-rand = "0.9"
+rand = "0.10"
 
 # Error handling
 thiserror = "2.0"
@@ -81,10 +81,10 @@ thiserror = "2.0"
 tracing = "0.1"
 
 # Ordered floats for bin boundaries
-ordered-float = "4.5"
+ordered-float = "5.3"
 
 # CLI argument parsing
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 
 # Serialization framework
 serde = { version = "1.0", features = ["derive"] }
@@ -93,34 +93,34 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # CSV serialization for tuner logging
-csv = "1.3"
+csv = "1.4"
 
 # Binary serialization for model files
-bincode = "1.3"
+bincode = "2"
 
 # CRC32 for integrity checks in .trb files
 crc32fast = "1.5"
 
 # File locking for concurrent access prevention
-fs4 = "0.13"
+fs4 = "1.1"
 
 # Timestamp for run directories
 chrono = "0.4"
 
 # Python bindings (optional)
-pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
 
 # NumPy support for Python bindings
-numpy = { version = "0.23", optional = true }
+numpy = { version = "0.28", optional = true }
 
 # GPU compute via WebGPU (optional - for gpu feature)
-wgpu = { version = "27", optional = true }
+wgpu = { version = "29", optional = true }
 
 # Async executor for blocking WGPU calls (optional - for gpu feature)
 pollster = { version = "0.4", optional = true }
 
 # CUDA driver bindings (optional - for cuda feature)
-cudarc = { version = "=0.18.2", optional = true, default-features = false, features = [
+cudarc = { version = "=0.19.7", optional = true, default-features = false, features = [
   "driver",
   "nvrtc",
   "dynamic-linking",
@@ -131,15 +131,15 @@ cudarc = { version = "=0.18.2", optional = true, default-features = false, featu
 memmap2 = { version = "0.9", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 approx = "0.5"
-tempfile = "3.15"
-fastrand = "2.3"
-rand_distr = "0.5"  # For statistical distributions in stress tests (compatible with rand 0.9)
+tempfile = "3.27"
+fastrand = "2.4"
+rand_distr = "0.6"  # For statistical distributions in stress tests (compatible with rand 0.10)
 
 # Competitor GBDT implementations for benchmarking
 gbdt = { version = "0.1", features = ["enable_training"] }
-forust-ml = "0.4"
+forust-ml = "0.5"
 
 [[bench]]
 name = "competitors"

--- a/benches/competitors.rs
+++ b/benches/competitors.rs
@@ -5,8 +5,9 @@
 //! - gbdt-rs (Baidu's pure-Rust GBDT)
 //! - forust (modern histogram-based GBDT)
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::prelude::*;
+use std::hint::black_box;
 use std::time::Duration;
 
 // TreeBoost imports

--- a/benches/competitors.rs
+++ b/benches/competitors.rs
@@ -34,12 +34,12 @@ fn generate_regression_data(
     for _ in 0..num_rows {
         let mut row_sum = 0.0;
         for f in 0..num_features {
-            let val: f64 = rng.gen_range(0.0..10.0);
+            let val: f64 = rng.random_range(0.0..10.0);
             features.push(val);
             // Target is weighted sum of features with some noise
             row_sum += val * (f as f64 + 1.0) * 0.1;
         }
-        let noise: f64 = rng.gen_range(-1.0..1.0);
+        let noise: f64 = rng.random_range(-1.0..1.0);
         targets.push(row_sum + noise);
     }
 

--- a/benches/correctness.rs
+++ b/benches/correctness.rs
@@ -508,7 +508,7 @@ fn main() {
     print_header("RELATIVE PERFORMANCE SUMMARY");
 
     println!("\nAccuracy ranking (by R²):");
-    let mut rankings = vec![
+    let mut rankings = [
         ("TreeBoost", tb_r2),
         ("gbdt-rs", gbdt_r2),
         ("forust", for_r2),
@@ -519,23 +519,23 @@ fn main() {
     }
 
     println!("\nTraining time ranking:");
-    let mut train_times = vec![
+    let mut train_times = [
         ("TreeBoost", treeboost_train_time),
         ("gbdt-rs", gbdt_train_time),
         ("forust", forust_train_time),
     ];
-    train_times.sort_by(|a, b| a.1.cmp(&b.1));
+    train_times.sort_by_key(|a| a.1);
     for (i, (name, time)) in train_times.iter().enumerate() {
         println!("  {}. {} ({:?})", i + 1, name, time);
     }
 
     println!("\nPrediction time ranking:");
-    let mut pred_times = vec![
+    let mut pred_times = [
         ("TreeBoost", treeboost_pred_time),
         ("gbdt-rs", gbdt_pred_time),
         ("forust", forust_pred_time),
     ];
-    pred_times.sort_by(|a, b| a.1.cmp(&b.1));
+    pred_times.sort_by_key(|a| a.1);
     for (i, (name, time)) in pred_times.iter().enumerate() {
         println!("  {}. {} ({:?})", i + 1, name, time);
     }

--- a/benches/correctness.rs
+++ b/benches/correctness.rs
@@ -31,12 +31,12 @@ fn generate_regression_data(
     for _ in 0..num_rows {
         let mut row_sum = 0.0;
         for f in 0..num_features {
-            let val: f64 = rng.gen_range(0.0..10.0);
+            let val: f64 = rng.random_range(0.0..10.0);
             features.push(val);
             // Target is weighted sum of features with some noise
             row_sum += val * (f as f64 + 1.0) * 0.1;
         }
-        let noise: f64 = rng.gen_range(-0.5..0.5);
+        let noise: f64 = rng.random_range(-0.5..0.5);
         targets.push(row_sum + noise);
     }
 
@@ -82,6 +82,7 @@ fn to_treeboost_dataset(
             feature_type: FeatureType::Numeric,
             num_bins: (boundaries.len() + 1).min(255) as u8,
             bin_boundaries: boundaries,
+            impute_value: 0.0,
         });
     }
 

--- a/benches/profile.rs
+++ b/benches/profile.rs
@@ -19,11 +19,11 @@ fn generate_data(num_rows: usize, num_features: usize, seed: u64) -> (Vec<f32>, 
     for _ in 0..num_rows {
         let mut row_sum = 0.0f32;
         for f in 0..num_features {
-            let val: f32 = rng.gen_range(0.0..10.0);
+            let val: f32 = rng.random_range(0.0..10.0);
             features.push(val);
             row_sum += val * (f as f32 + 1.0) * 0.1;
         }
-        targets.push(row_sum + rng.gen_range(-1.0..1.0));
+        targets.push(row_sum + rng.random_range(-1.0..1.0));
     }
 
     (features, targets)

--- a/benches/profile.rs
+++ b/benches/profile.rs
@@ -3,8 +3,9 @@
 //! Measures training and inference performance across dataset sizes.
 //! Fast execution (~3-5 minutes total) with consistent synthetic data.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::prelude::*;
+use std::hint::black_box;
 use std::time::Duration;
 
 use treeboost::backend::BackendType;

--- a/examples/automl_profile.rs
+++ b/examples/automl_profile.rs
@@ -7,7 +7,7 @@
 ///!   cargo run --release --example automl_profile -- [--sample]
 use polars::prelude::*;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use std::time::Instant;
 use treeboost::analysis::{AnalysisConfig, DatasetAnalysis, PanelDataInfo};
 use treeboost::dataset::{BinnedDataset, DatasetLoader};
@@ -70,7 +70,7 @@ fn run_profile(num_rows: usize) -> Result<()> {
     let unique_dates: Vec<i64> = dates_col
         .as_materialized_series()
         .i64()?
-        .into_iter()
+        .iter()
         .filter_map(|v| v)
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
@@ -191,7 +191,7 @@ fn profile_analysis_internals(dataset: &BinnedDataset, config: &AnalysisConfig) 
         indices.push(i);
     }
     for i in max_sample_rows..num_rows {
-        let j = rng.gen_range(0..=i);
+        let j = rng.random_range(0..=i);
         if j < max_sample_rows {
             indices[j] = i;
         }
@@ -334,13 +334,13 @@ fn generate_synthetic_panel_data(num_rows: usize) -> Result<DataFrame> {
 
     // Add features
     for f_idx in 0..num_features {
-        let values: Vec<f64> = (0..actual_rows).map(|_| rng.gen::<f64>() * 100.0).collect();
+        let values: Vec<f64> = (0..actual_rows).map(|_| rng.random::<f64>() * 100.0).collect();
         all_columns.push(Column::new(format!("f_{}", f_idx).into(), values));
     }
 
     // Generate and add target
     let targets: Vec<f32> = (0..actual_rows)
-        .map(|_| rng.gen::<f32>() * 2.0 - 1.0) // Returns in [-1, 1]
+        .map(|_| rng.random::<f32>() * 2.0 - 1.0) // Returns in [-1, 1]
         .collect();
     all_columns.push(Column::new("y".into(), targets));
 

--- a/examples/automl_profile.rs
+++ b/examples/automl_profile.rs
@@ -344,7 +344,7 @@ fn generate_synthetic_panel_data(num_rows: usize) -> Result<DataFrame> {
         .collect();
     all_columns.push(Column::new("y".into(), targets));
 
-    let df = DataFrame::new(all_columns)?;
+    let df = DataFrame::new(actual_rows, all_columns)?;
 
     Ok(df)
 }

--- a/examples/automl_profile.rs
+++ b/examples/automl_profile.rs
@@ -1,17 +1,16 @@
-///! Profiling example for AutoML pipeline
-///!
-///! This example profiles the AutoML pipeline to identify bottlenecks,
-///! particularly in the Analysis phase (40% → 50%) after Dataset Preparation.
-///!
-///! Run with:
-///!   cargo run --release --example automl_profile -- [--sample]
+//! Profiling example for AutoML pipeline
+//!
+//! This example profiles the AutoML pipeline to identify bottlenecks,
+//! particularly in the Analysis phase (40% → 50%) after Dataset Preparation.
+//!
+//! Run with:
+//!   cargo run --release --example automl_profile -- [--sample]
 use polars::prelude::*;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 use std::time::Instant;
-use treeboost::analysis::{AnalysisConfig, DatasetAnalysis, PanelDataInfo};
+use treeboost::analysis::{AnalysisConfig, DatasetAnalysis};
 use treeboost::dataset::{BinnedDataset, DatasetLoader};
-use treeboost::features::SmartFeatureEngine;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -41,7 +40,7 @@ fn run_profile(num_rows: usize) -> Result<()> {
     let phase0_start = Instant::now();
     println!("[  0%] Generating synthetic panel data...");
 
-    let mut train_df = generate_synthetic_panel_data(num_rows)?;
+    let train_df = generate_synthetic_panel_data(num_rows)?;
 
     println!(
         "[  5%] Data generated: {} rows × {} cols [{:.2?}]",
@@ -71,7 +70,7 @@ fn run_profile(num_rows: usize) -> Result<()> {
         .as_materialized_series()
         .i64()?
         .iter()
-        .filter_map(|v| v)
+        .flatten()
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .collect();
@@ -334,7 +333,9 @@ fn generate_synthetic_panel_data(num_rows: usize) -> Result<DataFrame> {
 
     // Add features
     for f_idx in 0..num_features {
-        let values: Vec<f64> = (0..actual_rows).map(|_| rng.random::<f64>() * 100.0).collect();
+        let values: Vec<f64> = (0..actual_rows)
+            .map(|_| rng.random::<f64>() * 100.0)
+            .collect();
         all_columns.push(Column::new(format!("f_{}", f_idx).into(), values));
     }
 

--- a/examples/classification.rs
+++ b/examples/classification.rs
@@ -187,7 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("7. Probability Distribution:");
 
     // Probability bins
-    let mut prob_bins = vec![0usize; 10];
+    let mut prob_bins = [0usize; 10];
     for prob in &probabilities {
         let bin = ((prob * 10.0).min(9.0)) as usize;
         prob_bins[bin] += 1;

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -53,8 +53,8 @@ pub fn extract_subset(dataset: &BinnedDataset, start_row: usize, end_row: usize)
     let mut features = Vec::with_capacity(n_rows * n_features);
     for f in 0..n_features {
         let col = dataset.feature_column(f);
-        for r in start_row..end_row {
-            features.push(col[r]);
+        for &val in &col[start_row..end_row] {
+            features.push(val);
         }
     }
 

--- a/examples/linear_tree.rs
+++ b/examples/linear_tree.rs
@@ -57,7 +57,7 @@ fn create_synthetic_dataset(
                 2.0 * f0 + 1.0 * f1 + noise
             } else {
                 // Region 2: negative slope on f0, offset
-                -1.0 * f0 + 3.0 * f1 + 2.0 + noise
+                -f0 + 3.0 * f1 + 2.0 + noise
             }
         })
         .collect();

--- a/examples/multilabel.rs
+++ b/examples/multilabel.rs
@@ -54,14 +54,17 @@ fn create_multilabel_dataframe(n_samples: usize, seed: u64) -> DataFrame {
         .map(|(&a, &c)| if a + c > 5.5 { 1 } else { 0 })
         .collect();
 
-    DataFrame::new(n_samples, vec![
-        Column::new("x1".into(), x1),
-        Column::new("x2".into(), x2),
-        Column::new("x3".into(), x3),
-        Column::new("label_0".into(), label_0),
-        Column::new("label_1".into(), label_1),
-        Column::new("label_2".into(), label_2),
-    ])
+    DataFrame::new(
+        n_samples,
+        vec![
+            Column::new("x1".into(), x1),
+            Column::new("x2".into(), x2),
+            Column::new("x3".into(), x3),
+            Column::new("label_0".into(), label_0),
+            Column::new("label_1".into(), label_1),
+            Column::new("label_2".into(), label_2),
+        ],
+    )
     .unwrap()
 }
 

--- a/examples/multilabel.rs
+++ b/examples/multilabel.rs
@@ -54,7 +54,7 @@ fn create_multilabel_dataframe(n_samples: usize, seed: u64) -> DataFrame {
         .map(|(&a, &c)| if a + c > 5.5 { 1 } else { 0 })
         .collect();
 
-    DataFrame::new(vec![
+    DataFrame::new(n_samples, vec![
         Column::new("x1".into(), x1),
         Column::new("x2".into(), x2),
         Column::new("x3".into(), x3),

--- a/examples/target_encoding.rs
+++ b/examples/target_encoding.rs
@@ -80,7 +80,7 @@ fn main() {
     println!();
 
     // Simulate ordered target encoding
-    let training_data = vec![
+    let training_data = [
         ("cat_a", 1.2),
         ("cat_b", 2.5),
         ("cat_a", 1.8),
@@ -93,7 +93,7 @@ fn main() {
     let mut encodings: std::collections::HashMap<&str, Vec<f32>> = std::collections::HashMap::new();
 
     for (i, (cat, target)) in training_data.iter().enumerate() {
-        encodings.entry(cat).or_insert_with(Vec::new).push(*target);
+        encodings.entry(cat).or_default().push(*target);
         let mean_so_far = encodings[cat].iter().sum::<f32>() / encodings[cat].len() as f32;
         println!(
             "     Row {}: category='{}', target={:.1}, encoding (mean so far)={:.4}",

--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -360,7 +360,7 @@ impl DatasetAnalysis {
 
         // --- Sample indices for efficiency ---
         let sample_indices: Option<Vec<usize>> = if num_rows > config.max_sample_rows {
-            use rand::Rng;
+            use rand::RngExt;
             use rand::SeedableRng;
 
             // OPTIMIZED: Reservoir sampling instead of shuffle
@@ -579,7 +579,7 @@ impl DatasetAnalysis {
 
         // --- Sample indices for efficiency ---
         let sample_indices: Option<Vec<usize>> = if num_rows > config.max_sample_rows {
-            use rand::Rng;
+            use rand::RngExt;
             use rand::SeedableRng;
 
             // OPTIMIZED: Direct random sampling instead of shuffle

--- a/src/analysis/analyzer.rs
+++ b/src/analysis/analyzer.rs
@@ -276,7 +276,7 @@ impl DatasetAnalysis {
         let targets: Vec<f32> = target_series
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(f32::NAN))
             .collect();
 
@@ -323,7 +323,7 @@ impl DatasetAnalysis {
                 // Safe to cast numeric types
                 if let Ok(numeric_series) = col.cast(&DataType::Float32) {
                     if let Ok(vals) = numeric_series.f32() {
-                        for (r_idx, val) in vals.into_iter().enumerate() {
+                        for (r_idx, val) in vals.iter().enumerate() {
                             raw_features[r_idx * num_features + f_idx] = val.unwrap_or(f32::NAN);
                         }
                     }
@@ -336,7 +336,7 @@ impl DatasetAnalysis {
                     let mut category_map: HashMap<&str, f32> = HashMap::new();
                     let mut next_code = 0f32;
 
-                    for (r_idx, val) in str_series.into_iter().enumerate() {
+                    for (r_idx, val) in str_series.iter().enumerate() {
                         if let Some(s) = val {
                             let code = *category_map.entry(s).or_insert_with(|| {
                                 let c = next_code;

--- a/src/analysis/profiler.rs
+++ b/src/analysis/profiler.rs
@@ -507,13 +507,13 @@ impl ColumnProfile {
             return false;
         };
 
-        let mut row_idx = 0;
         let mut expected_val = None;
         let mut is_sequential = true;
         let mut sample_count = 0;
         let max_samples = 1000;
 
-        for opt_val in ca.iter() {
+        for (row_idx, opt_val) in ca.iter().enumerate() {
+            let row_idx = row_idx as i64;
             if sample_count >= max_samples {
                 break;
             }
@@ -546,7 +546,6 @@ impl ColumnProfile {
 
                 sample_count += 1;
             }
-            row_idx += 1;
         }
 
         is_sequential && sample_count > 10
@@ -1254,12 +1253,15 @@ mod tests {
 
     #[test]
     fn test_dataframe_profile() {
-        let df = DataFrame::new(5, vec![
-            Series::new("feature1".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-            Series::new("feature2".into(), vec!["a", "b", "a", "b", "a"]).into(),
-            Series::new("constant".into(), vec![1.0f64, 1.0, 1.0, 1.0, 1.0]).into(),
-            Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new("feature1".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+                Series::new("feature2".into(), vec!["a", "b", "a", "b", "a"]).into(),
+                Series::new("constant".into(), vec![1.0f64, 1.0, 1.0, 1.0, 1.0]).into(),
+                Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
+            ],
+        )
         .unwrap();
 
         let profile = DataFrameProfile::analyze(&df, "target").unwrap();
@@ -1312,7 +1314,7 @@ mod tests {
         use chrono::{Datelike, NaiveDate};
 
         // Create panel-like data: 2 stocks × 5 days = 10 rows
-        let dates: Vec<i32> = vec![
+        let dates: Vec<i32> = [
             NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
             NaiveDate::from_ymd_opt(2024, 1, 2).unwrap(),
             NaiveDate::from_ymd_opt(2024, 1, 3).unwrap(),
@@ -1328,34 +1330,38 @@ mod tests {
         .map(|d| d.num_days_from_ce())
         .collect();
 
-        let df = DataFrame::new(10, vec![
-            Series::new(
-                "stock_code".into(),
-                vec![
-                    "AAPL", "AAPL", "AAPL", "AAPL", "AAPL", "GOOGL", "GOOGL", "GOOGL", "GOOGL",
-                    "GOOGL",
-                ],
-            )
-            .into(),
-            Series::new("date".into(), dates)
-                .cast(&PolarsDataType::Date)
-                .unwrap()
+        let df = DataFrame::new(
+            10,
+            vec![
+                Series::new(
+                    "stock_code".into(),
+                    vec![
+                        "AAPL", "AAPL", "AAPL", "AAPL", "AAPL", "GOOGL", "GOOGL", "GOOGL", "GOOGL",
+                        "GOOGL",
+                    ],
+                )
                 .into(),
-            Series::new(
-                "price".into(),
-                vec![
-                    150.0f64, 151.0, 152.0, 151.5, 153.0, 2800.0, 2810.0, 2805.0, 2820.0, 2830.0,
-                ],
-            )
-            .into(),
-            Series::new(
-                "target".into(),
-                vec![
-                    0.01f64, 0.02, -0.01, 0.01, 0.02, 0.01, -0.01, 0.02, 0.01, 0.01,
-                ],
-            )
-            .into(),
-        ])
+                Series::new("date".into(), dates)
+                    .cast(&PolarsDataType::Date)
+                    .unwrap()
+                    .into(),
+                Series::new(
+                    "price".into(),
+                    vec![
+                        150.0f64, 151.0, 152.0, 151.5, 153.0, 2800.0, 2810.0, 2805.0, 2820.0,
+                        2830.0,
+                    ],
+                )
+                .into(),
+                Series::new(
+                    "target".into(),
+                    vec![
+                        0.01f64, 0.02, -0.01, 0.01, 0.02, 0.01, -0.01, 0.02, 0.01, 0.01,
+                    ],
+                )
+                .into(),
+            ],
+        )
         .unwrap();
 
         let profile = DataFrameProfile::analyze(&df, "target").unwrap();
@@ -1376,11 +1382,14 @@ mod tests {
     #[test]
     fn test_no_panel_without_datetime() {
         // Data without datetime column - should not detect panel
-        let df = DataFrame::new(5, vec![
-            Series::new("category".into(), vec!["A", "A", "B", "B", "C"]).into(),
-            Series::new("value".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-            Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new("category".into(), vec!["A", "A", "B", "B", "C"]).into(),
+                Series::new("value".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+                Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
+            ],
+        )
         .unwrap();
 
         let profile = DataFrameProfile::analyze(&df, "target").unwrap();
@@ -1405,14 +1414,17 @@ mod tests {
             })
             .collect();
 
-        let df = DataFrame::new(5, vec![
-            Series::new("date".into(), dates)
-                .cast(&PolarsDataType::Date)
-                .unwrap()
-                .into(),
-            Series::new("value".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-            Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new("date".into(), dates)
+                    .cast(&PolarsDataType::Date)
+                    .unwrap()
+                    .into(),
+                Series::new("value".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+                Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
+            ],
+        )
         .unwrap();
 
         let profile = DataFrameProfile::analyze(&df, "target").unwrap();

--- a/src/analysis/profiler.rs
+++ b/src/analysis/profiler.rs
@@ -1254,7 +1254,7 @@ mod tests {
 
     #[test]
     fn test_dataframe_profile() {
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new("feature1".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
             Series::new("feature2".into(), vec!["a", "b", "a", "b", "a"]).into(),
             Series::new("constant".into(), vec![1.0f64, 1.0, 1.0, 1.0, 1.0]).into(),
@@ -1328,7 +1328,7 @@ mod tests {
         .map(|d| d.num_days_from_ce())
         .collect();
 
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(10, vec![
             Series::new(
                 "stock_code".into(),
                 vec![
@@ -1376,7 +1376,7 @@ mod tests {
     #[test]
     fn test_no_panel_without_datetime() {
         // Data without datetime column - should not detect panel
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new("category".into(), vec!["A", "A", "B", "B", "C"]).into(),
             Series::new("value".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
             Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
@@ -1405,7 +1405,7 @@ mod tests {
             })
             .collect();
 
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new("date".into(), dates)
                 .cast(&PolarsDataType::Date)
                 .unwrap()

--- a/src/analysis/profiler.rs
+++ b/src/analysis/profiler.rs
@@ -422,7 +422,7 @@ impl ColumnProfile {
         let values: Vec<f64> = column
             .cast(&PolarsDataType::Float64)
             .ok()
-            .and_then(|c| c.f64().ok().map(|ca| ca.into_iter().flatten().collect()))
+            .and_then(|c| c.f64().ok().map(|ca| ca.iter().flatten().collect()))
             .unwrap_or_default();
 
         if values.len() < 3 {
@@ -513,7 +513,7 @@ impl ColumnProfile {
         let mut sample_count = 0;
         let max_samples = 1000;
 
-        for opt_val in ca.into_iter() {
+        for opt_val in ca.iter() {
             if sample_count >= max_samples {
                 break;
             }
@@ -698,7 +698,7 @@ impl DataFrameProfile {
             .map_err(|e| TreeBoostError::Data(format!("Cannot convert target to numeric: {}", e)))?
             .f64()
             .map_err(|e| TreeBoostError::Data(format!("Target column error: {}", e)))?
-            .into_iter()
+            .iter()
             .map(|opt| opt.map(|v| v as f32).unwrap_or(f32::NAN))
             .collect();
 
@@ -1025,7 +1025,7 @@ impl DataFrameProfile {
                     .and_then(|c| {
                         c.i32()
                             .ok()
-                            .map(|ca| ca.into_iter().flatten().map(|v| v as f64).collect())
+                            .map(|ca| ca.iter().flatten().map(|v| v as f64).collect())
                     })
                     .unwrap_or_default()
             }
@@ -1036,7 +1036,7 @@ impl DataFrameProfile {
                     .ok()
                     .and_then(|c| {
                         c.i64().ok().map(|ca| {
-                            ca.into_iter()
+                            ca.iter()
                                 .flatten()
                                 .map(|v| v as f64 / (1_000_000.0 * 86400.0)) // microseconds to days
                                 .collect()

--- a/src/backend/cuda/full_gpu.rs
+++ b/src/backend/cuda/full_gpu.rs
@@ -18,7 +18,6 @@ use crate::histogram::Histogram;
 use crate::tree::{Node, NodeType, SplitInfo, Tree};
 use crate::utils::approx_equal_relative;
 use cudarc::driver::CudaSlice;
-use rand::SeedableRng;
 use std::sync::Arc;
 
 /// Full CUDA tree builder using level-wise growth with GPU-resident data.

--- a/src/backend/cuda/kernels.rs
+++ b/src/backend/cuda/kernels.rs
@@ -250,7 +250,7 @@ impl HistogramKernel {
         let stream = self.device.stream();
 
         // Zero output histograms
-        let zero_blocks = ((output_bins + 255) / 256) as u32;
+        let zero_blocks = output_bins.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks, 1, 1),
@@ -273,7 +273,7 @@ impl HistogramKernel {
         // Calculate 2D grid dimensions
         // grid.x = num_features, grid.y = row_tiles
         let rows_per_tile = THREADS_PER_BLOCK;
-        let row_tiles = ((num_indices as u32) + rows_per_tile - 1) / rows_per_tile;
+        let row_tiles = (num_indices as u32).div_ceil(rows_per_tile);
 
         // Shared memory: 256 * (f32 + f32 + u32) = 256 * 12 = 3072 bytes
         let shared_mem_bytes = 256 * (4 + 4 + 4);
@@ -329,11 +329,9 @@ impl HistogramKernel {
                 let mut hess = [0.0f32; 256];
                 let mut counts = [0u32; 256];
 
-                for bin in 0..256 {
-                    grads[bin] = grad_hist[base + bin];
-                    hess[bin] = hess_hist[base + bin];
-                    counts[bin] = count_hist[base + bin];
-                }
+                grads.copy_from_slice(&grad_hist[base..base + 256]);
+                hess.copy_from_slice(&hess_hist[base..base + 256]);
+                counts.copy_from_slice(&count_hist[base..base + 256]);
 
                 Histogram::from_raw_arrays(&grads, &hess, &counts)
             })
@@ -438,7 +436,7 @@ impl HistogramKernel {
         let stream = self.device.stream();
 
         // Zero output histograms
-        let zero_blocks = ((output_size + 255) / 256) as u32;
+        let zero_blocks = output_size.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks, 1, 1),
@@ -459,7 +457,7 @@ impl HistogramKernel {
         }
 
         // Grid: (num_features, num_batches * tiles_per_batch)
-        let tiles_per_batch = ((max_count as u32) + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+        let tiles_per_batch = (max_count as u32).div_ceil(THREADS_PER_BLOCK);
         let shared_mem_bytes = 256 * (4 + 4 + 4);
 
         let config = LaunchConfig {
@@ -521,11 +519,9 @@ impl HistogramKernel {
                         let mut hess = [0.0f32; 256];
                         let mut counts = [0u32; 256];
 
-                        for bin in 0..256 {
-                            grads[bin] = grad_hist[base + bin];
-                            hess[bin] = hess_hist[base + bin];
-                            counts[bin] = count_hist[base + bin];
-                        }
+                        grads.copy_from_slice(&grad_hist[base..base + 256]);
+                        hess.copy_from_slice(&hess_hist[base..base + 256]);
+                        counts.copy_from_slice(&count_hist[base..base + 256]);
 
                         Histogram::from_raw_arrays(&grads, &hess, &counts)
                     })
@@ -592,7 +588,7 @@ impl HistogramKernel {
         let stream = self.device.stream();
 
         // Zero output histograms
-        let zero_blocks = ((output_size + 255) / 256) as u32;
+        let zero_blocks = output_size.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks, 1, 1),
@@ -613,7 +609,7 @@ impl HistogramKernel {
         }
 
         // Grid: (num_features, tiles_per_node, num_nodes) - split into Y and Z to stay under 65535
-        let tiles_per_node = ((max_node_count as u32) + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+        let tiles_per_node = (max_node_count as u32).div_ceil(THREADS_PER_BLOCK);
         let shared_mem_bytes = 256 * (4 + 4 + 4);
 
         let config = LaunchConfig {
@@ -680,11 +676,9 @@ impl HistogramKernel {
                         let mut hess = [0.0f32; 256];
                         let mut counts = [0u32; 256];
 
-                        for bin in 0..256 {
-                            grads[bin] = grad_hist[base + bin];
-                            hess[bin] = hess_hist[base + bin];
-                            counts[bin] = count_hist[base + bin];
-                        }
+                        grads.copy_from_slice(&grad_hist[base..base + 256]);
+                        hess.copy_from_slice(&hess_hist[base..base + 256]);
+                        counts.copy_from_slice(&count_hist[base..base + 256]);
 
                         Histogram::from_raw_arrays(&grads, &hess, &counts)
                     })
@@ -697,6 +691,8 @@ impl HistogramKernel {
     ///
     /// Returns histograms indexed as `[era][feature]`, enabling directional
     /// agreement checks across eras during split finding.
+    // reason: kernel/training entry point with many parameters
+    #[allow(clippy::too_many_arguments)]
     pub fn build_era_histograms(
         &mut self,
         bins: &[u8],
@@ -783,7 +779,7 @@ impl HistogramKernel {
         let stream = self.device.stream();
 
         // Zero output histograms
-        let zero_blocks = ((output_size + 255) / 256) as u32;
+        let zero_blocks = output_size.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks, 1, 1),
@@ -864,11 +860,9 @@ impl HistogramKernel {
                         let mut hess = [0.0f32; 256];
                         let mut counts = [0u32; 256];
 
-                        for bin in 0..256 {
-                            grads[bin] = grad_hist[base + bin];
-                            hess[bin] = hess_hist[base + bin];
-                            counts[bin] = count_hist[base + bin];
-                        }
+                        grads.copy_from_slice(&grad_hist[base..base + 256]);
+                        hess.copy_from_slice(&hess_hist[base..base + 256]);
+                        counts.copy_from_slice(&count_hist[base..base + 256]);
 
                         Histogram::from_raw_arrays(&grads, &hess, &counts)
                     })

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -53,10 +53,7 @@ pub struct CudaBackend {
 impl CudaBackend {
     /// Create a new CUDA backend if a compatible GPU is available.
     pub fn new() -> Option<Self> {
-        let device = match CudaDevice::new() {
-            Some(d) => d,
-            None => return None,
-        };
+        let device = CudaDevice::new()?;
         let device = Arc::new(device);
         let histogram_kernel = Mutex::new(HistogramKernel::new(Arc::clone(&device)));
 

--- a/src/backend/cuda/partition.rs
+++ b/src/backend/cuda/partition.rs
@@ -421,7 +421,7 @@ impl PartitionKernel {
         // Launch partition kernel
         let config = LaunchConfig {
             block_dim: (256, 1, 1),
-            grid_dim: (((num_indices + 255) / 256) as u32, 1, 1),
+            grid_dim: (num_indices.div_ceil(256) as u32, 1, 1),
             shared_mem_bytes: 0,
         };
         unsafe {
@@ -545,7 +545,7 @@ impl PartitionKernel {
         let stream = self.device.stream();
 
         // Zero counters
-        let zero_blocks = ((num_counters + 255) / 256) as u32;
+        let zero_blocks = num_counters.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks.max(1), 1, 1),
@@ -564,7 +564,7 @@ impl PartitionKernel {
         // Launch batched partition kernel
         // Grid: (num_nodes, row_tiles)
         let threads_per_block = 256u32;
-        let row_tiles = ((max_node_rows as u32) + threads_per_block - 1) / threads_per_block;
+        let row_tiles = (max_node_rows as u32).div_ceil(threads_per_block);
 
         let config = LaunchConfig {
             block_dim: (threads_per_block, 1, 1),
@@ -692,7 +692,7 @@ impl PartitionKernel {
         let stream = self.device.stream();
 
         // Zero counters
-        let zero_blocks = ((num_counters + 255) / 256) as u32;
+        let zero_blocks = num_counters.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks.max(1), 1, 1),
@@ -710,7 +710,7 @@ impl PartitionKernel {
 
         // Launch GPU-resident partition kernel
         let threads_per_block = 256u32;
-        let row_tiles = ((max_node_rows as u32) + threads_per_block - 1) / threads_per_block;
+        let row_tiles = (max_node_rows as u32).div_ceil(threads_per_block);
 
         let config = LaunchConfig {
             block_dim: (threads_per_block, 1, 1),
@@ -912,7 +912,7 @@ impl PartitionKernel {
         let stream = self.device.stream();
 
         // Zero counters
-        let zero_blocks = ((num_counters + 255) / 256) as u32;
+        let zero_blocks = num_counters.div_ceil(256) as u32;
         let zero_config = LaunchConfig {
             block_dim: (256, 1, 1),
             grid_dim: (zero_blocks.max(1), 1, 1),
@@ -935,7 +935,7 @@ impl PartitionKernel {
             .max()
             .unwrap_or(0);
         let threads_per_block = 256u32;
-        let row_tiles = ((max_node_rows as u32) + threads_per_block - 1) / threads_per_block;
+        let row_tiles = (max_node_rows as u32).div_ceil(threads_per_block);
 
         let config = LaunchConfig {
             block_dim: (threads_per_block, 1, 1),

--- a/src/backend/scalar/kernel/x86/histogram.rs
+++ b/src/backend/scalar/kernel/x86/histogram.rs
@@ -331,6 +331,8 @@ pub unsafe fn copy_gh_interleaved_avx2(
 }
 
 #[cfg(test)]
+// reason: index loops mirror the SIMD kernel layout under test.
+#[allow(clippy::needless_range_loop)]
 mod tests {
     use super::*;
 

--- a/src/backend/scalar/kernel/x86/merge.rs
+++ b/src/backend/scalar/kernel/x86/merge.rs
@@ -124,6 +124,8 @@ pub unsafe fn subtract_histogram_counts_avx2(
 }
 
 #[cfg(test)]
+// reason: index loops mirror the SIMD kernel layout under test.
+#[allow(clippy::needless_range_loop)]
 mod tests {
     use super::*;
 

--- a/src/backend/wgpu/device.rs
+++ b/src/backend/wgpu/device.rs
@@ -210,7 +210,7 @@ impl GpuDevice {
     /// Reads only the first `output.len()` elements from the staging buffer.
     /// Useful when the actual data size is smaller than the buffer capacity.
     pub fn read_buffer_partial<T: bytemuck::Pod>(&self, staging: &Buffer, output: &mut [T]) {
-        let byte_size = (output.len() * std::mem::size_of::<T>()) as u64;
+        let byte_size = std::mem::size_of_val(output) as u64;
         let slice = staging.slice(..byte_size);
         slice.map_async(wgpu::MapMode::Read, |_| {});
         let _ = self.device.poll(wgpu::PollType::Wait {
@@ -274,7 +274,7 @@ impl GpuDevice {
 
     /// Get maximum storage buffer binding size.
     pub fn max_storage_buffer_size(&self) -> u64 {
-        self.limits.max_storage_buffer_binding_size as u64
+        self.limits.max_storage_buffer_binding_size
     }
 }
 

--- a/src/backend/wgpu/device.rs
+++ b/src/backend/wgpu/device.rs
@@ -43,8 +43,8 @@ impl GpuDevice {
             .await
             .ok()?;
 
-        // Adapter info for debugging
-        let _info = adapter.get_info();
+        // Adapter info (also exposes subgroup size range in wgpu 29+)
+        let info = adapter.get_info();
 
         // Get device limits
         let limits = adapter.limits();
@@ -76,9 +76,9 @@ impl GpuDevice {
             Err(_) => return None,
         };
 
-        // Get subgroup size limits from adapter limits
+        // Get subgroup size range from adapter info (moved off Limits in wgpu 29)
         let (min_subgroup_size, max_subgroup_size) = if subgroups_supported {
-            (limits.min_subgroup_size, limits.max_subgroup_size)
+            (info.subgroup_min_size, info.subgroup_max_size)
         } else {
             (0, 0)
         };

--- a/src/backend/wgpu/full_gpu.rs
+++ b/src/backend/wgpu/full_gpu.rs
@@ -69,6 +69,8 @@ impl FullGpuTreeBuilder {
     ///
     /// Key optimization: Histogram subtraction - only build GPU histograms for
     /// the smaller sibling, compute larger via: parent - smaller (~50% less GPU work).
+    // reason: kernel/training entry point with many parameters
+    #[allow(clippy::too_many_arguments)]
     pub fn build_tree(
         &mut self,
         dataset: &BinnedDataset,
@@ -387,6 +389,8 @@ impl FullGpuTreeBuilder {
     /// - GPU histogram building (for smaller child only)
     /// - CPU histogram subtraction (fast arithmetic)
     /// - GPU partition with in-place CPU array management
+    // reason: kernel/training entry point with many parameters
+    #[allow(clippy::too_many_arguments)]
     pub fn build_tree_best_first(
         &mut self,
         dataset: &BinnedDataset,

--- a/src/backend/wgpu/kernels.rs
+++ b/src/backend/wgpu/kernels.rs
@@ -393,7 +393,7 @@ impl HistogramKernel {
 
         let indices_u32: Vec<u32> = row_indices.iter().map(|&i| i as u32).collect();
 
-        let bins_aligned = bins_row_major.len() % 4 == 0;
+        let bins_aligned = bins_row_major.len().is_multiple_of(4);
         let bins_packed_owned: Vec<u32>;
         let bins_packed: &[u32] = if bins_aligned {
             bytemuck::cast_slice(bins_row_major)
@@ -534,7 +534,7 @@ impl HistogramKernel {
             pass.set_pipeline(&self.pipeline_zero);
             pass.set_bind_group(0, &bind_group_zero, &[]);
             let total_bins = (num_features * 256) as u32;
-            let workgroups = (total_bins + 255) / 256;
+            let workgroups = total_bins.div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -648,7 +648,7 @@ impl HistogramKernel {
         let indices_u32: Vec<u32> = row_indices.iter().map(|&i| i as u32).collect();
 
         // For bins, try zero-copy cast if aligned, else pack
-        let bins_aligned = bins_row_major.len() % 4 == 0;
+        let bins_aligned = bins_row_major.len().is_multiple_of(4);
         let bins_packed_owned: Vec<u32>;
         let bins_packed: &[u32] = if bins_aligned {
             // Zero-copy: interpret bytes directly as u32s
@@ -816,7 +816,7 @@ impl HistogramKernel {
             pass.set_pipeline(&self.pipeline_zero);
             pass.set_bind_group(0, &bind_group_zero, &[]);
             let total_bins = (num_features * 256) as u32;
-            let workgroups = (total_bins + 255) / 256;
+            let workgroups = total_bins.div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -941,7 +941,7 @@ impl HistogramKernel {
         let indices_u32: Vec<u32> = row_indices.iter().map(|&i| i as u32).collect();
 
         // Pack 4-bit bins for GPU (already nibble-packed, just need u32 alignment)
-        let bins_aligned = bins_4bit.len() % 4 == 0;
+        let bins_aligned = bins_4bit.len().is_multiple_of(4);
         let bins_packed_owned: Vec<u32>;
         let bins_packed: &[u32] = if bins_aligned {
             bytemuck::cast_slice(bins_4bit)
@@ -1101,7 +1101,7 @@ impl HistogramKernel {
             pass.set_pipeline(&self.pipeline_zero_4bit);
             pass.set_bind_group(0, &bind_group_zero, &[]);
             let total_bins = (num_features * 256) as u32;
-            let workgroups = (total_bins + 255) / 256;
+            let workgroups = total_bins.div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -1222,7 +1222,7 @@ impl HistogramKernel {
 
         // Pack bins
         let t = Instant::now();
-        let bins_aligned = bins_row_major.len() % 4 == 0;
+        let bins_aligned = bins_row_major.len().is_multiple_of(4);
         let bins_packed_owned: Vec<u32>;
         let bins_packed: &[u32] = if bins_aligned {
             bytemuck::cast_slice(bins_row_major)
@@ -1395,7 +1395,7 @@ impl HistogramKernel {
             pass.set_pipeline(&self.pipeline_zero);
             pass.set_bind_group(0, &bind_group_zero, &[]);
             let total_bins = (num_features * 256) as u32;
-            let workgroups = (total_bins + 255) / 256;
+            let workgroups = total_bins.div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -1599,7 +1599,7 @@ impl HistogramKernel {
         }
 
         // For bins, try zero-copy cast if aligned, else pack
-        let bins_aligned = bins_row_major.len() % 4 == 0;
+        let bins_aligned = bins_row_major.len().is_multiple_of(4);
         let bins_packed_owned: Vec<u32>;
         let bins_packed: &[u32] = if bins_aligned {
             bytemuck::cast_slice(bins_row_major)
@@ -1781,7 +1781,7 @@ impl HistogramKernel {
             pass.set_pipeline(&self.pipeline_zero_batched);
             pass.set_bind_group(0, &bind_group_zero, &[]);
             let total_bins = (num_batches * num_features * 256) as u32;
-            let workgroups = (total_bins + 255) / 256;
+            let workgroups = total_bins.div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -1894,6 +1894,8 @@ impl HistogramKernel {
     ///
     /// # Returns
     /// 2D vector of histograms: `[num_eras][num_features]`
+    // reason: kernel/training entry point with many parameters
+    #[allow(clippy::too_many_arguments)]
     pub fn build_era_histograms(
         &self,
         bins_row_major: &[u8],
@@ -1930,7 +1932,7 @@ impl HistogramKernel {
             .collect();
 
         // Pack bins
-        let bins_aligned = bins_row_major.len() % 4 == 0;
+        let bins_aligned = bins_row_major.len().is_multiple_of(4);
         let bins_packed_owned: Vec<u32>;
         let bins_packed: &[u32] = if bins_aligned {
             bytemuck::cast_slice(bins_row_major)
@@ -2110,7 +2112,7 @@ impl HistogramKernel {
             pass.set_pipeline(&self.pipeline_zero_era);
             pass.set_bind_group(0, &bind_group_zero, &[]);
             let total_bins = (num_eras * num_features * 256) as u32;
-            let workgroups = (total_bins + 255) / 256;
+            let workgroups = total_bins.div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -2207,7 +2209,7 @@ impl HistogramKernel {
 
 /// Pack u8 bins into u32 array (4 bytes per u32).
 fn pack_bins_u32(bins: &[u8]) -> Vec<u32> {
-    let mut packed = vec![0u32; (bins.len() + 3) / 4];
+    let mut packed = vec![0u32; bins.len().div_ceil(4)];
     for (i, &bin) in bins.iter().enumerate() {
         let word_idx = i / 4;
         let byte_idx = i % 4;

--- a/src/backend/wgpu/mod.rs
+++ b/src/backend/wgpu/mod.rs
@@ -545,7 +545,7 @@ mod tests {
         // Generate gradients and hessians with varied values
         let grad_hess: Vec<(f32, f32)> = (0..num_rows)
             .map(|i| {
-                let g = ((i as f32 * 0.01).sin() * 10.0) as f32;
+                let g = (i as f32 * 0.01).sin() * 10.0;
                 let h = 1.0 + (i % 10) as f32 * 0.1;
                 (g, h)
             })

--- a/src/backend/wgpu/partition.rs
+++ b/src/backend/wgpu/partition.rs
@@ -194,7 +194,7 @@ impl PartitionKernel {
             };
         }
 
-        let num_blocks = (num_indices as u32 + Self::WORKGROUP_SIZE - 1) / Self::WORKGROUP_SIZE;
+        let num_blocks = (num_indices as u32).div_ceil(Self::WORKGROUP_SIZE);
 
         // Calculate buffer sizes
         let bins_size = (bins_packed.len() * 4) as u64;
@@ -404,7 +404,7 @@ impl PartitionKernel {
         // Calculate buffer sizes
         let bins_size = (bins_packed.len() * 4) as u64;
         let indices_size = (total_rows.max(1) * 4) as u64;
-        let node_splits_size = (num_nodes * std::mem::size_of::<NodeSplit>()) as u64;
+        let node_splits_size = std::mem::size_of_val(node_splits) as u64;
         let node_counters_size = (num_nodes * 2 * 4) as u64; // left + right per node
 
         let batched_params = BatchedPartitionParams {
@@ -544,7 +544,7 @@ impl PartitionKernel {
             });
             pass.set_pipeline(&self.pipeline_zero_node_counters);
             pass.set_bind_group(0, &bind_group_zero, &[]);
-            let workgroups = (num_nodes as u32 * 2 + 255) / 256;
+            let workgroups = (num_nodes as u32 * 2).div_ceil(256);
             pass.dispatch_workgroups(workgroups, 1, 1);
         }
 
@@ -682,7 +682,7 @@ mod tests {
         // Create simple test data
         // 4 rows, 2 features, row-major bins
         // Row 0: [0, 1], Row 1: [2, 3], Row 2: [4, 5], Row 3: [6, 7]
-        let bins = vec![0u8, 1, 2, 3, 4, 5, 6, 7];
+        let bins = [0u8, 1, 2, 3, 4, 5, 6, 7];
         let bins_packed: Vec<u32> = bins
             .chunks(4)
             .map(|chunk| {

--- a/src/booster/config.rs
+++ b/src/booster/config.rs
@@ -754,7 +754,7 @@ impl GBDTConfig {
 
     /// Enable conformal prediction
     pub fn with_conformal(mut self, calibration_ratio: f32, quantile: f32) -> crate::Result<Self> {
-        if calibration_ratio < 0.0 || calibration_ratio >= 1.0 {
+        if !(0.0..1.0).contains(&calibration_ratio) {
             return Err(crate::TreeBoostError::Config(format!(
                 "calibration_ratio must be in [0, 1), got {}",
                 calibration_ratio

--- a/src/booster/training.rs
+++ b/src/booster/training.rs
@@ -615,7 +615,7 @@ impl GBDTModel {
             .with_entropy_weight(config.entropy_weight)
             .with_min_gain(config.min_gain);
 
-        for round in 0..config.num_rounds {
+        for _round in 0..config.num_rounds {
             // Grow tree - either fused, Full GPU, or separate gradient+histogram paths
             #[allow(unused_mut, unused_assignments)]
             let mut tree: Option<Tree> = None;

--- a/src/booster/training.rs
+++ b/src/booster/training.rs
@@ -643,7 +643,7 @@ impl GBDTModel {
                         config.learning_rate,
                         &split_finder,
                         config.colsample,
-                        config.seed.wrapping_add(round as u64),
+                        config.seed.wrapping_add(_round as u64),
                     ));
                 }
             }
@@ -670,7 +670,7 @@ impl GBDTModel {
                         config.learning_rate,
                         &split_finder,
                         config.colsample,
-                        config.seed.wrapping_add(round as u64),
+                        config.seed.wrapping_add(_round as u64),
                     ));
                 }
             }

--- a/src/booster/training.rs
+++ b/src/booster/training.rs
@@ -109,11 +109,7 @@ impl GBDTModel {
         config: GBDTConfig,
         feature_names: Option<Vec<String>>,
     ) -> Result<Self> {
-        let num_rows = if num_features > 0 {
-            features.len() / num_features
-        } else {
-            0
-        };
+        let num_rows = features.len().checked_div(num_features).unwrap_or(0);
 
         if num_rows == 0 || num_features == 0 {
             return Err(TreeBoostError::Config("Empty dataset".to_string()));
@@ -313,11 +309,7 @@ impl GBDTModel {
         config: GBDTConfig,
         feature_names: Option<Vec<String>>,
     ) -> Result<Self> {
-        let num_rows = if num_features > 0 {
-            features.len() / num_features
-        } else {
-            0
-        };
+        let num_rows = features.len().checked_div(num_features).unwrap_or(0);
 
         if num_rows == 0 || num_features == 0 {
             return Err(TreeBoostError::Config("Empty dataset".to_string()));
@@ -585,9 +577,9 @@ impl GBDTModel {
         validation_indices: &[usize],
         calibration_indices: &[usize],
         base_prediction: f32,
-        predictions: &mut Vec<f32>,
-        gradients: &mut Vec<f32>,
-        hessians: &mut Vec<f32>,
+        predictions: &mut [f32],
+        gradients: &mut [f32],
+        hessians: &mut [f32],
         tree_grower: TreeGrower,
         trees: &mut Vec<Tree>,
         rng: &mut rand::rngs::StdRng,
@@ -596,7 +588,7 @@ impl GBDTModel {
         rounds_without_improvement: &mut usize,
         best_num_trees: &mut usize,
         sample_indices: &mut Vec<usize>,
-        shuffle_buffer: &mut Vec<usize>,
+        shuffle_buffer: &mut [usize],
         goss_indexed: &mut Vec<(usize, f32)>,
         use_fused: bool,
         #[cfg(feature = "cuda")] cuda_builder: &mut Option<FullCudaTreeBuilder>,
@@ -754,8 +746,8 @@ impl GBDTModel {
             }
 
             // Update predictions with the new tree
-            for idx in 0..predictions.len() {
-                predictions[idx] += tree.predict(|f| dataset.get_bin(idx, f));
+            for (idx, pred) in predictions.iter_mut().enumerate() {
+                *pred += tree.predict(|f| dataset.get_bin(idx, f));
             }
 
             trees.push(tree);
@@ -777,7 +769,7 @@ impl GBDTModel {
                     *best_val_loss = val_loss;
                     *best_num_trees = trees.len();
                     *rounds_without_improvement = 0;
-                    if trees.len() % 50 == 0 {
+                    if trees.len().is_multiple_of(50) {
                         eprintln!(
                             "[ES] Round {}: val_loss={:.6} (NEW BEST), best_trees={}",
                             trees.len(),
@@ -787,7 +779,7 @@ impl GBDTModel {
                     }
                 } else {
                     *rounds_without_improvement += 1;
-                    if trees.len() % 50 == 0
+                    if trees.len().is_multiple_of(50)
                         || *rounds_without_improvement == config.early_stopping_rounds
                     {
                         eprintln!(
@@ -1089,6 +1081,7 @@ impl GBDTModel {
     /// * `dataset` - Multi-output binned dataset (targets row-wise flattened)
     /// * `config` - Training configuration with multi-label loss
     /// * `num_outputs` - Number of labels/outputs
+    ///
     /// Train multi-label model using unified Vector Trees
     ///
     /// Uses `VectorTreeGrower` to produce one `VectorTree` per round where each leaf

--- a/src/dataset/core/dataset.rs
+++ b/src/dataset/core/dataset.rs
@@ -1260,11 +1260,11 @@ mod tests {
         // Verify row-major format: [row0_feat0, row0_feat1, row1_feat0, row1_feat1, ...]
         // Row 0: (0, 10), Row 1: (1, 11), Row 2: (2, 12), Row 3: (3, 13)
         assert_eq!(row_major.len(), num_rows * num_features);
-        assert_eq!(row_major[0 * num_features + 0], 0); // row 0, feature 0
-        assert_eq!(row_major[0 * num_features + 1], 10); // row 0, feature 1
-        assert_eq!(row_major[1 * num_features + 0], 1); // row 1, feature 0
-        assert_eq!(row_major[1 * num_features + 1], 11); // row 1, feature 1
-        assert_eq!(row_major[3 * num_features + 0], 3); // row 3, feature 0
+        assert_eq!(row_major[0], 0); // row 0, feature 0
+        assert_eq!(row_major[1], 10); // row 0, feature 1
+        assert_eq!(row_major[num_features], 1); // row 1, feature 0
+        assert_eq!(row_major[num_features + 1], 11); // row 1, feature 1
+        assert_eq!(row_major[3 * num_features], 3); // row 3, feature 0
         assert_eq!(row_major[3 * num_features + 1], 13); // row 3, feature 1
 
         // Verify caching (second call returns same data)

--- a/src/dataset/feature_extractor.rs
+++ b/src/dataset/feature_extractor.rs
@@ -190,7 +190,7 @@ impl ColumnType {
         match series.dtype() {
             DataType::Int32 => {
                 if let Ok(ca) = series.i32() {
-                    let vals: Vec<Option<i32>> = ca.into_iter().collect();
+                    let vals: Vec<Option<i32>> = ca.iter().collect();
                     for i in 1..vals.len() {
                         if let (Some(a), Some(b)) = (vals[i - 1], vals[i]) {
                             if b <= a {
@@ -205,7 +205,7 @@ impl ColumnType {
             }
             DataType::Int64 => {
                 if let Ok(ca) = series.i64() {
-                    let vals: Vec<Option<i64>> = ca.into_iter().collect();
+                    let vals: Vec<Option<i64>> = ca.iter().collect();
                     for i in 1..vals.len() {
                         if let (Some(a), Some(b)) = (vals[i - 1], vals[i]) {
                             if b <= a {
@@ -220,7 +220,7 @@ impl ColumnType {
             }
             DataType::UInt32 => {
                 if let Ok(ca) = series.u32() {
-                    let vals: Vec<Option<u32>> = ca.into_iter().collect();
+                    let vals: Vec<Option<u32>> = ca.iter().collect();
                     for i in 1..vals.len() {
                         if let (Some(a), Some(b)) = (vals[i - 1], vals[i]) {
                             if b <= a {

--- a/src/dataset/feature_extractor.rs
+++ b/src/dataset/feature_extractor.rs
@@ -517,7 +517,7 @@ impl FeatureExtractor {
             if should_exclude {
                 excluded_by_type
                     .entry(col_type)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(col_name_str.to_string());
                 continue;
             }
@@ -587,27 +587,9 @@ impl FeatureExtractor {
                 // May overflow on very large values
                 v.min(u32::MAX as u64) as f32
             }
-            AnyValue::Float32(v) => {
-                if v.is_finite() {
-                    v
-                } else {
-                    0.0
-                }
-            }
-            AnyValue::Float64(v) => {
-                if v.is_finite() {
-                    v as f32
-                } else {
-                    0.0
-                }
-            }
-            AnyValue::Boolean(v) => {
-                if v {
-                    1.0
-                } else {
-                    0.0
-                }
-            }
+            AnyValue::Float32(v) if v.is_finite() => v,
+            AnyValue::Float64(v) if v.is_finite() => v as f32,
+            AnyValue::Boolean(v) if v => 1.0,
             _ => 0.0,
         }
     }
@@ -651,7 +633,7 @@ mod tests {
     use super::*;
 
     fn create_test_dataframe() -> DataFrame {
-        let df = df!(
+        df!(
             "id" => &[1i32, 2, 3, 4, 5],
             "year" => &[2020i32, 2021, 2022, 2023, 2024],
             "rank" => &[1i32, 2, 3, 4, 5],
@@ -661,9 +643,7 @@ mod tests {
             "category" => &["A", "B", "A", "B", "A"],
             "target" => &[1.0f32, 2.0, 3.0, 4.0, 5.0],
         )
-        .unwrap();
-
-        df
+        .unwrap()
     }
 
     #[test]
@@ -740,9 +720,9 @@ mod tests {
 
         // Verify row-major ordering
         if num_features >= 2 {
-            let row_0_feat_0 = result.features[0 * num_features + 0];
-            let row_0_feat_1 = result.features[0 * num_features + 1];
-            let row_1_feat_0 = result.features[1 * num_features + 0];
+            let row_0_feat_0 = result.features[0]; // row 0, feature 0
+            let row_0_feat_1 = result.features[1]; // row 0, feature 1
+            let row_1_feat_0 = result.features[num_features];
 
             // Values should match the DataFrame
             assert_eq!(row_0_feat_0, 1.0); // numeric1 row 0
@@ -806,7 +786,7 @@ mod tests {
         let result = extractor.extract_numeric_features(&df, "target").unwrap();
 
         // NaN should be filled with 0
-        assert_eq!(result.features[1 * result.num_features], 0.0);
+        assert_eq!(result.features[result.num_features], 0.0);
     }
 
     #[test]

--- a/src/dataset/io/loader.rs
+++ b/src/dataset/io/loader.rs
@@ -200,7 +200,7 @@ impl DatasetLoader {
         let mut next_idx = 0u16;
 
         let indices: Vec<u16> = str_ca
-            .into_iter()
+            .iter()
             .map(|opt| {
                 opt.map_or(0, |s| {
                     *era_map.entry(s.to_string()).or_insert_with(|| {
@@ -255,7 +255,7 @@ impl DatasetLoader {
             .map_err(|e| TreeBoostError::Data(format!("Failed to cast to f64: {}", e)))?
             .f64()
             .map_err(|e| TreeBoostError::Data(format!("Failed to get f64 chunked: {}", e)))?
-            .into_iter()
+            .iter()
             .map(|opt| Ok(opt.unwrap_or(f64::NAN)))
             .collect()
     }
@@ -267,7 +267,7 @@ impl DatasetLoader {
             .map_err(|e| TreeBoostError::Data(format!("Failed to cast to f32: {}", e)))?
             .f32()
             .map_err(|e| TreeBoostError::Data(format!("Failed to get f32 chunked: {}", e)))?
-            .into_iter()
+            .iter()
             .map(|opt| Ok(opt.unwrap_or(f32::NAN)))
             .collect()
     }
@@ -291,7 +291,7 @@ impl DatasetLoader {
         let mut next_idx = 0u32;
 
         let values: Vec<f64> = str_ca
-            .into_iter()
+            .iter()
             .map(|opt| match opt {
                 Some(s) => {
                     let idx = *mapping.entry(s.to_string()).or_insert_with(|| {

--- a/src/dataset/io/loader.rs
+++ b/src/dataset/io/loader.rs
@@ -28,7 +28,7 @@ impl DatasetLoader {
         target_column: &str,
         feature_columns: Option<&[&str]>,
     ) -> Result<BinnedDataset> {
-        let pl_path = PlPath::new(&path.as_ref().to_string_lossy());
+        let pl_path = PlRefPath::new(&*path.as_ref().to_string_lossy());
         let df = LazyFrame::scan_parquet(pl_path, Default::default())?.collect()?;
         self.from_dataframe(df, target_column, feature_columns)
     }
@@ -314,7 +314,7 @@ impl DatasetLoader {
         path: impl AsRef<Path>,
         feature_info: &[FeatureInfo],
     ) -> Result<BinnedDataset> {
-        let pl_path = PlPath::new(&path.as_ref().to_string_lossy());
+        let pl_path = PlRefPath::new(&*path.as_ref().to_string_lossy());
         let df = LazyFrame::scan_parquet(pl_path, Default::default())?.collect()?;
         self.from_dataframe_for_prediction(df, feature_info)
     }

--- a/src/dataset/pipeline/mod.rs
+++ b/src/dataset/pipeline/mod.rs
@@ -12,6 +12,8 @@
 //! - [`PipelineConfig`] - Configuration options
 //! - [`PipelineState`] - Learned state for inference
 
+// reason: renaming the inner module would be invasive; keep the conventional name.
+#[allow(clippy::module_inception)]
 mod pipeline;
 
 pub use pipeline::{CategoricalEncodingState, DataPipeline, PipelineConfig, PipelineState};

--- a/src/dataset/pipeline/pipeline.rs
+++ b/src/dataset/pipeline/pipeline.rs
@@ -149,7 +149,7 @@ impl DataPipeline {
         target_column: &str,
         categorical_columns: Option<&[&str]>,
     ) -> Result<(BinnedDataset, PipelineState, DataFrame)> {
-        let pl_path = PlPath::new(&path.as_ref().to_string_lossy());
+        let pl_path = PlRefPath::new(&*path.as_ref().to_string_lossy());
         let df = LazyFrame::scan_parquet(pl_path, Default::default())?.collect()?;
         self.process_for_training(df, target_column, categorical_columns, None)
     }
@@ -342,7 +342,7 @@ impl DataPipeline {
         let target_col = df.column(target_column)?;
         new_columns.push(target_col.clone());
 
-        let filtered_df = DataFrame::new(new_columns).map_err(|e| {
+        let filtered_df = DataFrame::new_infer_height(new_columns).map_err(|e| {
             TreeBoostError::Data(format!("Failed to build filtered DataFrame: {}", e))
         })?;
 
@@ -401,7 +401,7 @@ impl DataPipeline {
         path: impl AsRef<Path>,
         state: &PipelineState,
     ) -> Result<BinnedDataset> {
-        let pl_path = PlPath::new(&path.as_ref().to_string_lossy());
+        let pl_path = PlRefPath::new(&*path.as_ref().to_string_lossy());
         let df = LazyFrame::scan_parquet(pl_path, Default::default())?.collect()?;
         let (_preprocessed_df, dataset) = self.process_for_inference(df, state)?;
         Ok(dataset)
@@ -475,7 +475,7 @@ impl DataPipeline {
             .into_iter()
             .map(|s| s.into_column())
             .collect();
-        let preprocessed_df = DataFrame::new(columns).map_err(|e| {
+        let preprocessed_df = DataFrame::new_infer_height(columns).map_err(|e| {
             TreeBoostError::Data(format!("Failed to create preprocessed DataFrame: {}", e))
         })?;
 

--- a/src/dataset/pipeline/pipeline.rs
+++ b/src/dataset/pipeline/pipeline.rs
@@ -214,7 +214,7 @@ impl DataPipeline {
             .into_iter()
             .filter(|name| {
                 let name_str = name.as_str();
-                name_str != target_column && !era_column.map_or(false, |era| era == name_str)
+                name_str != target_column && (era_column != Some(name_str))
             })
             .map(|s| s.to_string())
             .collect();
@@ -537,7 +537,7 @@ impl DataPipeline {
             let mut sorted = non_nan_values.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let mid = sorted.len() / 2;
-            if sorted.len() % 2 == 0 {
+            if sorted.len().is_multiple_of(2) {
                 (sorted[mid - 1] + sorted[mid]) / 2.0
             } else {
                 sorted[mid]

--- a/src/dataset/pipeline/pipeline.rs
+++ b/src/dataset/pipeline/pipeline.rs
@@ -740,7 +740,7 @@ impl DataPipeline {
             .map_err(|e| TreeBoostError::Data(format!("Failed to cast to f64: {}", e)))?
             .f64()
             .map_err(|e| TreeBoostError::Data(format!("Failed to get f64 chunked: {}", e)))?
-            .into_iter()
+            .iter()
             .map(|opt| Ok(opt.unwrap_or(f64::NAN)))
             .collect()
     }
@@ -756,7 +756,7 @@ impl DataPipeline {
             .map_err(|e| TreeBoostError::Data(format!("Failed to get str chunked: {}", e)))?;
 
         Ok(str_chunked
-            .into_iter()
+            .iter()
             .map(|opt| opt.unwrap_or("").to_string())
             .collect())
     }
@@ -785,7 +785,7 @@ impl DataPipeline {
         let mut next_idx = 0u16;
 
         let indices: Vec<u16> = str_ca
-            .into_iter()
+            .iter()
             .map(|opt| {
                 opt.map_or(0, |s| {
                     *era_map.entry(s.to_string()).or_insert_with(|| {

--- a/src/dataset/split.rs
+++ b/src/dataset/split.rs
@@ -837,8 +837,8 @@ mod tests {
             let class_1_count = fold.iter().filter(|&&idx| labels[idx] == 1).count();
 
             // With 100 samples, 5 folds, each fold should have ~10 of each class
-            assert!(class_0_count >= 8 && class_0_count <= 12);
-            assert!(class_1_count >= 8 && class_1_count <= 12);
+            assert!((8..=12).contains(&class_0_count));
+            assert!((8..=12).contains(&class_1_count));
         }
     }
 
@@ -854,8 +854,8 @@ mod tests {
             let class_1_count = fold.iter().filter(|&&idx| labels[idx] == 1).count();
 
             // With 90/10 split in 5 folds: ~18 class 0, ~2 class 1 per fold
-            assert!(class_0_count >= 16 && class_0_count <= 20);
-            assert!(class_1_count >= 1 && class_1_count <= 3);
+            assert!((16..=20).contains(&class_0_count));
+            assert!((1..=3).contains(&class_1_count));
         }
     }
 

--- a/src/features/crosssectional.rs
+++ b/src/features/crosssectional.rs
@@ -77,13 +77,13 @@ pub fn apply_crosssectional_features_with_include(
             .collect()
     } else {
         // Otherwise, process all numeric columns (excluding group and exclusion list)
-        df.get_columns()
+        df.columns()
             .iter()
-            .filter(|s| {
-                let name = s.name().as_str();
-                s.dtype().is_numeric() && name != group_col && !exclude_cols.contains(&name)
+            .filter(|col| {
+                let name = col.name().as_str();
+                col.dtype().is_numeric() && name != group_col && !exclude_cols.contains(&name)
             })
-            .map(|s| s.name().to_string())
+            .map(|col| col.name().to_string())
             .collect()
     };
 
@@ -128,7 +128,7 @@ pub fn apply_crosssectional_features_with_include(
         let rank_col = compute_group_ranks(&result_with_stats, col_name, group_col)?;
 
         result = result_with_stats;
-        result.with_column(rank_col)?;
+        result.with_column(rank_col.into())?;
     }
 
     Ok(result)

--- a/src/features/crosssectional.rs
+++ b/src/features/crosssectional.rs
@@ -112,11 +112,11 @@ pub fn apply_crosssectional_features_with_include(
         let zscore_expr = when(std_expr.clone().gt(lit(0.0)))
             .then((col(col_name) - mean_expr.clone()) / std_expr)
             .otherwise(lit(0.0))
-            .alias(&format!("{}_zscore", col_name));
+            .alias(format!("{}_zscore", col_name));
 
         // Median difference: x - median
         let median_diff_expr =
-            (col(col_name) - median_expr).alias(&format!("{}_vs_median", col_name));
+            (col(col_name) - median_expr).alias(format!("{}_vs_median", col_name));
 
         // Apply window functions
         let result_with_stats = lazy
@@ -172,9 +172,9 @@ fn compute_group_ranks(df: &DataFrame, feature_col: &str, group_col: &str) -> Po
                         / (col("__group_size__").cast(DataType::Float64) - lit(1.0)),
                 )
                 .otherwise(lit(0.5)) // Single-element groups get 0.5
-                .alias(&format!("{}_rank", feature_col)),
+                .alias(format!("{}_rank", feature_col)),
         ])
-        .select([col(&format!("{}_rank", feature_col))])
+        .select([col(format!("{}_rank", feature_col))])
         .collect()?;
 
     Ok(result

--- a/src/features/crosssectional.rs
+++ b/src/features/crosssectional.rs
@@ -104,9 +104,9 @@ pub fn apply_crosssectional_features_with_include(
         let lazy = result.clone().lazy();
 
         // Compute group-wise statistics using window functions (FAST!)
-        let mean_expr = col(col_name).mean().over([col(group_col)]);
-        let std_expr = col(col_name).std(1).over([col(group_col)]);
-        let median_expr = col(col_name).median().over([col(group_col)]);
+        let mean_expr = col(col_name).mean().over([col(group_col)])?;
+        let std_expr = col(col_name).std(1).over([col(group_col)])?;
+        let median_expr = col(col_name).median().over([col(group_col)])?;
 
         // Z-score: (x - mean) / std
         let zscore_expr = when(std_expr.clone().gt(lit(0.0)))
@@ -155,12 +155,12 @@ fn compute_group_ranks(df: &DataFrame, feature_col: &str, group_col: &str) -> Po
                     },
                     None,
                 )
-                .over([col(group_col)])
+                .over([col(group_col)])?
                 .alias("__temp_rank__"),
             // Step 2: Get group size
             col(feature_col)
                 .count()
-                .over([col(group_col)])
+                .over([col(group_col)])?
                 .alias("__group_size__"),
         ])
         .with_columns([
@@ -210,7 +210,7 @@ mod tests {
             .unwrap()
             .f64()
             .unwrap()
-            .into_iter()
+            .iter()
             .take(3)
             .collect::<Vec<_>>();
 

--- a/src/features/dataframe.rs
+++ b/src/features/dataframe.rs
@@ -211,10 +211,10 @@ pub fn apply_timeseries_features(
 
     // Create new DataFrame with all time-series features
     let columns: Vec<_> = all_series.into_iter().map(|s| s.into_column()).collect();
-    let ts_df = DataFrame::new(columns)?;
+    let ts_df = DataFrame::new_infer_height(columns)?;
 
     // Horizontal stack - much faster than repeated with_column()
-    let new_df = df.hstack(ts_df.get_columns())?;
+    let new_df = df.hstack(ts_df.columns())?;
 
     Ok(new_df)
 }
@@ -262,9 +262,9 @@ pub fn apply_polynomial_features(
         cols
     } else {
         // Auto-detect numeric columns
-        df.get_columns()
+        df.columns()
             .iter()
-            .filter(|col| is_numeric(col))
+            .filter(|col| is_numeric(*col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -320,10 +320,10 @@ pub fn apply_polynomial_features(
 
     // Create new DataFrame with polynomial features
     let columns: Vec<_> = all_series.into_iter().map(|s| s.into_column()).collect();
-    let poly_df = DataFrame::new(columns)?;
+    let poly_df = DataFrame::new_infer_height(columns)?;
 
     // Horizontal stack - O(n) operation
-    let new_df = df.hstack(poly_df.get_columns())?;
+    let new_df = df.hstack(poly_df.columns())?;
 
     Ok(new_df)
 }
@@ -369,9 +369,9 @@ pub fn apply_ratio_features(
         cols
     } else {
         // Auto-detect numeric columns
-        df.get_columns()
+        df.columns()
             .iter()
-            .filter(|col| is_numeric(col))
+            .filter(|col| is_numeric(*col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -427,10 +427,10 @@ pub fn apply_ratio_features(
 
     // Create new DataFrame with ratio features
     let columns: Vec<_> = all_series.into_iter().map(|s| s.into_column()).collect();
-    let ratio_df = DataFrame::new(columns)?;
+    let ratio_df = DataFrame::new_infer_height(columns)?;
 
     // Horizontal stack - O(n) operation
-    let new_df = df.hstack(ratio_df.get_columns())?;
+    let new_df = df.hstack(ratio_df.columns())?;
 
     Ok(new_df)
 }
@@ -477,9 +477,9 @@ pub fn apply_interaction_features(
         cols
     } else {
         // Auto-detect numeric columns
-        df.get_columns()
+        df.columns()
             .iter()
-            .filter(|col| is_numeric(col))
+            .filter(|col| is_numeric(*col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -535,10 +535,10 @@ pub fn apply_interaction_features(
 
     // Create new DataFrame with interaction features
     let columns: Vec<_> = all_series.into_iter().map(|s| s.into_column()).collect();
-    let interaction_df = DataFrame::new(columns)?;
+    let interaction_df = DataFrame::new_infer_height(columns)?;
 
     // Horizontal stack - O(n) operation
-    let new_df = df.hstack(interaction_df.get_columns())?;
+    let new_df = df.hstack(interaction_df.columns())?;
 
     Ok(new_df)
 }
@@ -773,7 +773,7 @@ pub fn apply_feature_plan(
     if !plan.ratio_pairs.is_empty() {
         // Get numeric columns for name-to-index mapping
         let numeric_cols: Vec<String> = df
-            .get_columns()
+            .columns()
             .iter()
             .filter(|col| col.dtype().is_numeric())
             .map(|col| col.name().to_string())
@@ -804,7 +804,7 @@ pub fn apply_feature_plan(
     if !plan.interaction_pairs.is_empty() {
         // Get numeric columns for name-to-index mapping
         let numeric_cols: Vec<String> = df
-            .get_columns()
+            .columns()
             .iter()
             .filter(|col| col.dtype().is_numeric())
             .map(|col| col.name().to_string())
@@ -846,7 +846,7 @@ pub fn apply_feature_plan(
         // Nulls appear for rows without sufficient history (e.g., first rows of each group)
         // Only fill nulls/NaN on numeric columns (string columns don't support fill_nan)
         let numeric_fill: Vec<_> = df
-            .get_columns()
+            .columns()
             .iter()
             .filter(|c| c.dtype().is_numeric())
             .map(|c| col(c.name().clone()).fill_null(lit(0)).fill_nan(lit(0.0)))

--- a/src/features/dataframe.rs
+++ b/src/features/dataframe.rs
@@ -103,7 +103,7 @@ pub fn apply_timeseries_features(
 
     let group_ids: Vec<u32> = code_series
         .str()?
-        .into_iter()
+        .iter()
         .map(|v| {
             let code = v.unwrap_or("");
             *code_to_id.entry(code.to_string()).or_insert_with(|| {
@@ -120,7 +120,7 @@ pub fn apply_timeseries_features(
         .as_materialized_series()
         .cast(&DataType::Float64)?
         .f64()?
-        .into_iter()
+        .iter()
         .map(|v| v.unwrap_or(0.0))
         .collect();
 
@@ -140,7 +140,7 @@ pub fn apply_timeseries_features(
             .as_materialized_series()
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect::<Vec<f32>>();
         columns.push(col);
@@ -282,7 +282,7 @@ pub fn apply_polynomial_features(
             .as_materialized_series()
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect::<Vec<f32>>();
         columns.push(col);
@@ -389,7 +389,7 @@ pub fn apply_ratio_features(
             .as_materialized_series()
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect::<Vec<f32>>();
         columns.push(col);
@@ -497,7 +497,7 @@ pub fn apply_interaction_features(
             .as_materialized_series()
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect::<Vec<f32>>();
         columns.push(col);

--- a/src/features/dataframe.rs
+++ b/src/features/dataframe.rs
@@ -147,11 +147,10 @@ pub fn apply_timeseries_features(
     }
 
     // Interleave to row-major format
-    #[allow(clippy::needless_range_loop)]
     let mut feature_data: Vec<f32> = Vec::with_capacity(num_rows * num_features);
     for row_idx in 0..num_rows {
-        for col_idx in 0..num_features {
-            feature_data.push(columns[col_idx][row_idx]);
+        for col in &columns {
+            feature_data.push(col[row_idx]);
         }
     }
 
@@ -264,7 +263,7 @@ pub fn apply_polynomial_features(
         // Auto-detect numeric columns
         df.columns()
             .iter()
-            .filter(|col| is_numeric(*col))
+            .filter(|col| is_numeric(col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -289,11 +288,10 @@ pub fn apply_polynomial_features(
     }
 
     // Interleave to row-major format
-    #[allow(clippy::needless_range_loop)]
     let mut feature_data: Vec<f32> = Vec::with_capacity(num_rows * num_features);
     for row_idx in 0..num_rows {
-        for col_idx in 0..num_features {
-            feature_data.push(columns[col_idx][row_idx]);
+        for col in &columns {
+            feature_data.push(col[row_idx]);
         }
     }
 
@@ -371,7 +369,7 @@ pub fn apply_ratio_features(
         // Auto-detect numeric columns
         df.columns()
             .iter()
-            .filter(|col| is_numeric(*col))
+            .filter(|col| is_numeric(col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -396,11 +394,10 @@ pub fn apply_ratio_features(
     }
 
     // Interleave to row-major format
-    #[allow(clippy::needless_range_loop)]
     let mut feature_data: Vec<f32> = Vec::with_capacity(num_rows * num_features);
     for row_idx in 0..num_rows {
-        for col_idx in 0..num_features {
-            feature_data.push(columns[col_idx][row_idx]);
+        for col in &columns {
+            feature_data.push(col[row_idx]);
         }
     }
 
@@ -479,7 +476,7 @@ pub fn apply_interaction_features(
         // Auto-detect numeric columns
         df.columns()
             .iter()
-            .filter(|col| is_numeric(*col))
+            .filter(|col| is_numeric(col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -504,11 +501,10 @@ pub fn apply_interaction_features(
     }
 
     // Interleave to row-major format
-    #[allow(clippy::needless_range_loop)]
     let mut feature_data: Vec<f32> = Vec::with_capacity(num_rows * num_features);
     for row_idx in 0..num_rows {
-        for col_idx in 0..num_features {
-            feature_data.push(columns[col_idx][row_idx]);
+        for col in &columns {
+            feature_data.push(col[row_idx]);
         }
     }
 
@@ -541,123 +537,6 @@ pub fn apply_interaction_features(
     let new_df = df.hstack(interaction_df.columns())?;
 
     Ok(new_df)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_extract_all_features() {
-        let raw = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let result = extract_selected_features(&raw, 2, 3, None);
-        assert_eq!(result, raw);
-    }
-
-    #[test]
-    fn test_extract_selected_features() {
-        // 2 rows, 3 features per row
-        let raw = vec![
-            1.0, 2.0, 3.0, // row 0
-            4.0, 5.0, 6.0, // row 1
-        ];
-
-        // Select features 0 and 2
-        let indices = vec![0, 2];
-        let result = extract_selected_features(&raw, 2, 3, Some(&indices));
-
-        assert_eq!(
-            result,
-            vec![
-                1.0, 3.0, // row 0: features 0, 2
-                4.0, 6.0, // row 1: features 0, 2
-            ]
-        );
-    }
-
-    #[test]
-    fn test_extract_single_feature() {
-        let raw = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let indices = vec![1];
-        let result = extract_selected_features(&raw, 2, 3, Some(&indices));
-        assert_eq!(result, vec![2.0, 5.0]); // Feature 1 from each row
-    }
-
-    #[test]
-    fn test_extract_reordered_features() {
-        let raw = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let indices = vec![2, 0]; // Reverse order
-        let result = extract_selected_features(&raw, 2, 3, Some(&indices));
-        assert_eq!(result, vec![3.0, 1.0, 6.0, 4.0]);
-    }
-
-    #[test]
-    fn test_apply_polynomial_features() {
-        let df = df! {
-            "x" => &[1.0f32, 2.0, 4.0],
-            "y" => &[10.0f32, 20.0, 30.0],
-        }
-        .unwrap();
-
-        let gen = PolynomialGenerator::new(); // Default: x², sqrt
-        let result =
-            apply_polynomial_features(df.clone(), &gen, Some(vec!["x".to_string()])).unwrap();
-
-        // Should have original 2 columns + 2 new polynomial features for 'x'
-        assert_eq!(result.width(), 4);
-        assert_eq!(result.height(), 3);
-        let col_names: Vec<String> = result
-            .get_column_names()
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        assert!(col_names.contains(&"x_sq".to_string()));
-        assert!(col_names.contains(&"x_sqrt".to_string()));
-    }
-
-    #[test]
-    fn test_apply_ratio_features() {
-        let df = df! {
-            "a" => &[10.0f32, 20.0, 30.0],
-            "b" => &[2.0f32, 4.0, 5.0],
-        }
-        .unwrap();
-
-        let gen = RatioGenerator::from_pairs(vec![(0, 1)]); // a / b
-        let result = apply_ratio_features(df.clone(), &gen, None).unwrap();
-
-        // Should have original 2 columns + 1 ratio column
-        assert_eq!(result.width(), 3);
-        assert_eq!(result.height(), 3);
-        let col_names: Vec<String> = result
-            .get_column_names()
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        assert!(col_names.contains(&"a_div_b".to_string()));
-    }
-
-    #[test]
-    fn test_apply_interaction_features() {
-        let df = df! {
-            "a" => &[1.0f32, 2.0, 3.0],
-            "b" => &[4.0f32, 5.0, 6.0],
-        }
-        .unwrap();
-
-        let gen = InteractionGenerator::from_pairs(vec![(0, 1)]); // a * b by default
-        let result = apply_interaction_features(df.clone(), &gen, None).unwrap();
-
-        // Should have original 2 columns + 1 interaction column
-        assert_eq!(result.width(), 3);
-        assert_eq!(result.height(), 3);
-        let col_names: Vec<String> = result
-            .get_column_names()
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-        assert!(col_names.contains(&"a_mul_b".to_string()));
-    }
 }
 
 /// Apply cross-sectional ranking features to panel data
@@ -873,4 +752,121 @@ pub fn apply_feature_plan(
     }
 
     Ok(df)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_all_features() {
+        let raw = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let result = extract_selected_features(&raw, 2, 3, None);
+        assert_eq!(result, raw);
+    }
+
+    #[test]
+    fn test_extract_selected_features() {
+        // 2 rows, 3 features per row
+        let raw = vec![
+            1.0, 2.0, 3.0, // row 0
+            4.0, 5.0, 6.0, // row 1
+        ];
+
+        // Select features 0 and 2
+        let indices = vec![0, 2];
+        let result = extract_selected_features(&raw, 2, 3, Some(&indices));
+
+        assert_eq!(
+            result,
+            vec![
+                1.0, 3.0, // row 0: features 0, 2
+                4.0, 6.0, // row 1: features 0, 2
+            ]
+        );
+    }
+
+    #[test]
+    fn test_extract_single_feature() {
+        let raw = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let indices = vec![1];
+        let result = extract_selected_features(&raw, 2, 3, Some(&indices));
+        assert_eq!(result, vec![2.0, 5.0]); // Feature 1 from each row
+    }
+
+    #[test]
+    fn test_extract_reordered_features() {
+        let raw = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let indices = vec![2, 0]; // Reverse order
+        let result = extract_selected_features(&raw, 2, 3, Some(&indices));
+        assert_eq!(result, vec![3.0, 1.0, 6.0, 4.0]);
+    }
+
+    #[test]
+    fn test_apply_polynomial_features() {
+        let df = df! {
+            "x" => &[1.0f32, 2.0, 4.0],
+            "y" => &[10.0f32, 20.0, 30.0],
+        }
+        .unwrap();
+
+        let gen = PolynomialGenerator::new(); // Default: x², sqrt
+        let result =
+            apply_polynomial_features(df.clone(), &gen, Some(vec!["x".to_string()])).unwrap();
+
+        // Should have original 2 columns + 2 new polynomial features for 'x'
+        assert_eq!(result.width(), 4);
+        assert_eq!(result.height(), 3);
+        let col_names: Vec<String> = result
+            .get_column_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(col_names.contains(&"x_sq".to_string()));
+        assert!(col_names.contains(&"x_sqrt".to_string()));
+    }
+
+    #[test]
+    fn test_apply_ratio_features() {
+        let df = df! {
+            "a" => &[10.0f32, 20.0, 30.0],
+            "b" => &[2.0f32, 4.0, 5.0],
+        }
+        .unwrap();
+
+        let gen = RatioGenerator::from_pairs(vec![(0, 1)]); // a / b
+        let result = apply_ratio_features(df.clone(), &gen, None).unwrap();
+
+        // Should have original 2 columns + 1 ratio column
+        assert_eq!(result.width(), 3);
+        assert_eq!(result.height(), 3);
+        let col_names: Vec<String> = result
+            .get_column_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(col_names.contains(&"a_div_b".to_string()));
+    }
+
+    #[test]
+    fn test_apply_interaction_features() {
+        let df = df! {
+            "a" => &[1.0f32, 2.0, 3.0],
+            "b" => &[4.0f32, 5.0, 6.0],
+        }
+        .unwrap();
+
+        let gen = InteractionGenerator::from_pairs(vec![(0, 1)]); // a * b by default
+        let result = apply_interaction_features(df.clone(), &gen, None).unwrap();
+
+        // Should have original 2 columns + 1 interaction column
+        assert_eq!(result.width(), 3);
+        assert_eq!(result.height(), 3);
+        let col_names: Vec<String> = result
+            .get_column_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(col_names.contains(&"a_mul_b".to_string()));
+    }
 }

--- a/src/features/smart.rs
+++ b/src/features/smart.rs
@@ -1024,12 +1024,15 @@ mod tests {
     use polars::prelude::*;
 
     fn create_test_profile() -> DataFrameProfile {
-        let df = DataFrame::new(5, vec![
-            Series::new("feature1".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-            Series::new("feature2".into(), vec![2.0f64, 4.0, 6.0, 8.0, 10.0]).into(),
-            Series::new("feature3".into(), vec![5.0f64, 4.0, 3.0, 2.0, 1.0]).into(),
-            Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new("feature1".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+                Series::new("feature2".into(), vec![2.0f64, 4.0, 6.0, 8.0, 10.0]).into(),
+                Series::new("feature3".into(), vec![5.0f64, 4.0, 3.0, 2.0, 1.0]).into(),
+                Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+            ],
+        )
         .unwrap();
 
         DataFrameProfile::analyze(&df, "target").unwrap()
@@ -1074,15 +1077,18 @@ mod tests {
     #[test]
     fn test_skip_negative_polynomial() {
         // Create profile with negative values
-        let df = DataFrame::new(5, vec![
-            Series::new(
-                "negative_feature".into(),
-                vec![-1.0f64, -2.0, 3.0, 4.0, 5.0],
-            )
-            .into(),
-            Series::new("positive_feature".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-            Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new(
+                    "negative_feature".into(),
+                    vec![-1.0f64, -2.0, 3.0, 4.0, 5.0],
+                )
+                .into(),
+                Series::new("positive_feature".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+                Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+            ],
+        )
         .unwrap();
 
         let profile = DataFrameProfile::analyze(&df, "target").unwrap();
@@ -1178,10 +1184,13 @@ mod tests {
         use crate::analysis::{PanelDataInfo, TimeGranularity};
 
         // Profile with only categorical (no numerics)
-        let df = DataFrame::new(5, vec![
-            Series::new("cat1".into(), vec!["a", "b", "c", "d", "e"]).into(),
-            Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new("cat1".into(), vec!["a", "b", "c", "d", "e"]).into(),
+                Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+            ],
+        )
         .unwrap();
 
         let profile = DataFrameProfile::analyze(&df, "target").unwrap();

--- a/src/features/smart.rs
+++ b/src/features/smart.rs
@@ -1024,7 +1024,7 @@ mod tests {
     use polars::prelude::*;
 
     fn create_test_profile() -> DataFrameProfile {
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new("feature1".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
             Series::new("feature2".into(), vec![2.0f64, 4.0, 6.0, 8.0, 10.0]).into(),
             Series::new("feature3".into(), vec![5.0f64, 4.0, 3.0, 2.0, 1.0]).into(),
@@ -1074,7 +1074,7 @@ mod tests {
     #[test]
     fn test_skip_negative_polynomial() {
         // Create profile with negative values
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new(
                 "negative_feature".into(),
                 vec![-1.0f64, -2.0, 3.0, 4.0, 5.0],
@@ -1178,7 +1178,7 @@ mod tests {
         use crate::analysis::{PanelDataInfo, TimeGranularity};
 
         // Profile with only categorical (no numerics)
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new("cat1".into(), vec!["a", "b", "c", "d", "e"]).into(),
             Series::new("target".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
         ])

--- a/src/learner/linear.rs
+++ b/src/learner/linear.rs
@@ -286,7 +286,7 @@ impl LinearConfig {
     ///
     /// Returns error if l1_ratio is not in [0.0, 1.0].
     pub fn with_l1_ratio(mut self, l1_ratio: f32) -> Result<Self> {
-        if l1_ratio < 0.0 || l1_ratio > 1.0 {
+        if !(0.0..=1.0).contains(&l1_ratio) {
             return Err(crate::TreeBoostError::Config(format!(
                 "l1_ratio must be in [0, 1], got {}. Use 0.0 for Ridge, 1.0 for LASSO, 0.0-1.0 for Elastic Net",
                 l1_ratio
@@ -366,7 +366,7 @@ impl LinearConfig {
     ///
     /// Returns error if extrapolation_damping is not in [0.0, 1.0].
     pub fn with_extrapolation_damping(mut self, damping: f32) -> Result<Self> {
-        if damping < 0.0 || damping > 1.0 {
+        if !(0.0..=1.0).contains(&damping) {
             return Err(crate::TreeBoostError::Config(format!(
                 "extrapolation_damping must be in [0, 1], got {}",
                 damping
@@ -564,7 +564,7 @@ impl LinearBooster {
     ///
     /// # Arguments
     /// * `update_bias` - If true, recompute bias from data. If false, keep current bias
-    ///                   (for warm start where we want to continue from current state)
+    ///   (for warm start where we want to continue from current state)
     ///
     /// # Returns
     /// Number of iterations actually executed (may be less than max_iter due to convergence)
@@ -1047,7 +1047,7 @@ mod tests {
     fn test_linear_booster_simple_fit() -> Result<()> {
         // Simple linear relationship: y = 2*x + 1
         let features = vec![1.0, 2.0, 3.0, 4.0, 5.0]; // 5 rows, 1 feature
-        let targets = vec![3.0, 5.0, 7.0, 9.0, 11.0];
+        let targets = [3.0, 5.0, 7.0, 9.0, 11.0];
 
         // For gradient boosting, gradients = predictions - targets (for MSE)
         // Initial predictions = 0, so gradients = -targets
@@ -1089,7 +1089,7 @@ mod tests {
             1.0, 2.0, // row 2: y = 1 + 4 = 5
             2.0, 2.0, // row 3: y = 2 + 4 = 6
         ];
-        let targets = vec![3.0, 4.0, 5.0, 6.0];
+        let targets = [3.0, 4.0, 5.0, 6.0];
         let gradients: Vec<f32> = targets.iter().map(|&t| -t).collect();
         let hessians = vec![1.0; 4];
 

--- a/src/learner/linear_tree.rs
+++ b/src/learner/linear_tree.rs
@@ -742,13 +742,13 @@ mod tests {
             .unwrap();
 
         let batch_preds = booster.predict_batch(&dataset, &raw_features, 3);
-        for i in 0..50 {
+        for (i, &batch_pred) in batch_preds.iter().take(50).enumerate() {
             let single_pred = booster.predict_row(&dataset, &raw_features, 3, i);
             assert!(
-                (batch_preds[i] - single_pred).abs() < 1e-5,
+                (batch_pred - single_pred).abs() < 1e-5,
                 "Mismatch at row {}: batch={}, single={}",
                 i,
-                batch_preds[i],
+                batch_pred,
                 single_pred
             );
         }

--- a/src/loss/activation.rs
+++ b/src/loss/activation.rs
@@ -58,7 +58,12 @@ mod tests {
         for x in extreme_values {
             let s = sigmoid(x);
             assert!(s.is_finite(), "sigmoid({}) = {} is not finite", x, s);
-            assert!(s >= 0.0 && s <= 1.0, "sigmoid({}) = {} out of [0,1]", x, s);
+            assert!(
+                (0.0..=1.0).contains(&s),
+                "sigmoid({}) = {} out of [0,1]",
+                x,
+                s
+            );
         }
     }
 }

--- a/src/loss/focal.rs
+++ b/src/loss/focal.rs
@@ -221,7 +221,7 @@ impl MultiLabelFocalLoss {
         let num_rows = targets.len() / num_outputs;
         let mut initial = vec![0.0; num_outputs];
 
-        for output_idx in 0..num_outputs {
+        for (output_idx, init) in initial.iter_mut().enumerate() {
             let mut positive_count = 0.0;
             for row in 0..num_rows {
                 let idx = row * num_outputs + output_idx;
@@ -231,7 +231,7 @@ impl MultiLabelFocalLoss {
             }
 
             let p = (positive_count / num_rows as f32).clamp(self.eps, 1.0 - self.eps);
-            initial[output_idx] = (p / (1.0 - p)).ln();
+            *init = (p / (1.0 - p)).ln();
         }
 
         initial

--- a/src/loss/multilabel.rs
+++ b/src/loss/multilabel.rs
@@ -156,7 +156,7 @@ impl MultiLabelLogLoss {
         let num_rows = targets.len() / num_outputs;
         let mut initial = vec![0.0; num_outputs];
 
-        for output_idx in 0..num_outputs {
+        for (output_idx, init) in initial.iter_mut().enumerate() {
             // Count positives for this label
             let mut positive_count = 0.0;
             for row in 0..num_rows {
@@ -168,7 +168,7 @@ impl MultiLabelLogLoss {
 
             // Compute log-odds
             let p = (positive_count / num_rows as f32).clamp(self.eps, 1.0 - self.eps);
-            initial[output_idx] = (p / (1.0 - p)).ln();
+            *init = (p / (1.0 - p)).ln();
         }
 
         initial
@@ -253,9 +253,9 @@ impl MultiLabelLogLoss {
         let mut labels = vec![0.0; probabilities.len()];
 
         for row in 0..num_rows {
-            for output_idx in 0..num_outputs {
+            for (output_idx, &threshold) in thresholds.iter().enumerate() {
                 let idx = row * num_outputs + output_idx;
-                labels[idx] = if probabilities[idx] >= thresholds[output_idx] {
+                labels[idx] = if probabilities[idx] >= threshold {
                     1.0
                 } else {
                     0.0

--- a/src/loss/quantile.rs
+++ b/src/loss/quantile.rs
@@ -255,6 +255,6 @@ mod tests {
 
         // 25th percentile should be close to 2
         let init = loss.initial_prediction(&targets);
-        assert!(init >= 1.0 && init <= 3.0);
+        assert!((1.0..=3.0).contains(&init));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,7 +447,7 @@ fn main() -> Result<()> {
             let actual_targets: Option<Vec<f32>> = if let Some(ref target_col) = target {
                 use polars::prelude::*;
                 let df = if data.extension().and_then(|s| s.to_str()) == Some("parquet") {
-                    let pl_path = PlPath::new(&data.to_string_lossy());
+                    let pl_path = PlRefPath::new(&*data.to_string_lossy());
                     LazyFrame::scan_parquet(pl_path, Default::default())?.collect()?
                 } else {
                     CsvReadOptions::default()
@@ -708,7 +708,7 @@ fn main() -> Result<()> {
             println!("Loading data from {:?}...", data);
             let df = if data.extension().and_then(|s| s.to_str()) == Some("parquet") {
                 use polars::prelude::*;
-                let pl_path = PlPath::new(&data.to_string_lossy());
+                let pl_path = PlRefPath::new(&*data.to_string_lossy());
                 LazyFrame::scan_parquet(pl_path, Default::default())?.collect()?
             } else {
                 use polars::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -459,7 +459,7 @@ fn main() -> Result<()> {
                 let targets: Vec<f32> = series
                     .cast(&DataType::Float32)?
                     .f32()?
-                    .into_iter()
+                    .iter()
                     .map(|opt| opt.unwrap_or(f32::NAN))
                     .collect();
                 Some(targets)

--- a/src/model/auto.rs
+++ b/src/model/auto.rs
@@ -483,7 +483,7 @@ impl AutoModel {
 
         // For LinearThenTree, use dual-representation inference if FeatureExtractor is stored
         if matches!(self.mode, crate::model::BoostingMode::LinearThenTree) {
-            if let Some(ref extractor) = self.model.feature_extractor() {
+            if let Some(extractor) = self.model.feature_extractor() {
                 // CRITICAL: Extract from preprocessed_df (with encoded categoricals),
                 // NOT from original df (with String categoricals)
                 let (raw_features, _num_features) =
@@ -517,12 +517,12 @@ impl AutoModel {
         let (preprocessed_df, dataset) = self.prepare_dataset_for_prediction(df)?;
 
         // Extract features using FeatureExtractor
-        if let Some(ref extractor) = self.model.feature_extractor() {
+        if let Some(extractor) = self.model.feature_extractor() {
             let (raw_features, _num_features) =
                 extractor.extract(&preprocessed_df, &self.target_column)?;
 
             // Get linear-only predictions from the model
-            return Ok(self.model.predict_linear_only(&dataset, &raw_features)?);
+            return self.model.predict_linear_only(&dataset, &raw_features);
         }
 
         Err(TreeBoostError::Config(

--- a/src/model/builder.rs
+++ b/src/model/builder.rs
@@ -1060,7 +1060,7 @@ impl AutoBuilder {
                     let target_f32: Vec<f32> = target_series
                         .cast(&polars::datatypes::DataType::Float32)?
                         .f32()?
-                        .into_iter()
+                        .iter()
                         .map(|v| v.unwrap_or(0.0))
                         .collect();
 

--- a/src/model/builder.rs
+++ b/src/model/builder.rs
@@ -564,7 +564,7 @@ impl AutoBuilder {
             None, // panel_info will be added for time-series features below
         )?;
 
-        if self.config.verbose.enabled() && feature_plan.as_ref().map_or(false, |p| !p.is_empty()) {
+        if self.config.verbose.enabled() && feature_plan.as_ref().is_some_and(|p| !p.is_empty()) {
             let added = working_df.width() - initial_cols;
             let num_poly = feature_plan
                 .as_ref()
@@ -1156,10 +1156,8 @@ impl AutoBuilder {
 
             let num_total_features = col_names.len() - 1; // -1 for target
             if num_total_features == 0 {
-                return Err(TreeBoostError::Data(format!(
-                        "LinearThenTree mode requires features for the tree model, but none were found!\n\n\
-                         This should not happen if linear features exist. Please report this as a bug."
-                    )));
+                return Err(TreeBoostError::Data("LinearThenTree mode requires features for the tree model, but none were found!\n\n\
+                         This should not happen if linear features exist. Please report this as a bug.".to_string()));
             }
 
             (
@@ -1381,7 +1379,7 @@ impl AutoBuilder {
             target_transform: target_transform.clone(),
             build_time: start.elapsed(),
             phase_times,
-            validation_dataset: validation_dataset,
+            validation_dataset,
         };
 
         // Auto-save artifacts if model_output_dir is configured

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -281,9 +281,10 @@ impl TuningLevel {
 /// let config = AutoConfig::new()
 ///     .with_target_bound_config(TargetBoundConfig::ClampEmpirical);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum TargetBoundConfig {
     /// No target transformation (unbounded regression)
+    #[default]
     None,
 
     /// Logit transform with user-specified bounds.
@@ -303,12 +304,6 @@ pub enum TargetBoundConfig {
     /// Clamp-only with bounds from training data min/max.
     /// Simpler bounded regression using empirical bounds.
     ClampEmpirical,
-}
-
-impl Default for TargetBoundConfig {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// Ensemble strategy for AutoBuilder (PureTree only)
@@ -394,24 +389,19 @@ impl AutoEnsembleConfig {
 ///     ))
 ///     .fit(&df, "target")?;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum FeatureEngineeringMode {
     /// No feature engineering
     None,
     /// Minimal features (polynomial only, max 20)
     Minimal,
     /// Standard features (polynomial + interactions, max 50)
+    #[default]
     Default,
     /// Aggressive features (all types, max 100)
     Aggressive,
     /// Custom configuration
     Custom(crate::features::SmartFeatureConfig),
-}
-
-impl Default for FeatureEngineeringMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl FeatureEngineeringMode {
@@ -464,24 +454,19 @@ impl FeatureEngineeringMode {
 ///     ))
 ///     .fit(&df, "target")?;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum PreprocessingMode {
     /// No preprocessing
     None,
     /// Minimal preprocessing (basic imputation only)
     Minimal,
     /// Standard preprocessing (default)
+    #[default]
     Default,
     /// Strict preprocessing (aggressive cleaning)
     Strict,
     /// Custom configuration
     Custom(crate::preprocessing::SmartPreprocessConfig),
-}
-
-impl Default for PreprocessingMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 impl PreprocessingMode {
@@ -540,9 +525,10 @@ impl PreprocessingMode {
 ///     ))
 ///     .fit(&df, "target")?;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum EnsembleMode {
     /// No ensemble (single model)
+    #[default]
     Disabled,
     /// Default ensemble (Ridge stacking with 5 seeds)
     Default,
@@ -550,12 +536,6 @@ pub enum EnsembleMode {
     WithMethod(AutoEnsembleMethod),
     /// Custom ensemble configuration
     Custom(AutoEnsembleConfig),
-}
-
-impl Default for EnsembleMode {
-    fn default() -> Self {
-        Self::Disabled
-    }
 }
 
 impl EnsembleMode {
@@ -1656,6 +1636,12 @@ impl TreeTunerConfig {
             TreeTunerPreset::Standard => Self::preset_standard(),
             TreeTunerPreset::Thorough => Self::preset_thorough(),
         }
+    }
+}
+
+impl Default for TreeTunerConfig {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/model/pipeline/steps.rs
+++ b/src/model/pipeline/steps.rs
@@ -457,7 +457,7 @@ impl PipelineStep for EngineerFeaturesStep {
                     .collect();
 
                 let new_series = Series::new(lut.output_name().as_str().into(), mapped);
-                df = df.with_column(new_series)?.clone();
+                df = df.with_column(new_series.into())?.clone();
             }
         }
 
@@ -481,7 +481,7 @@ impl PipelineStep for EngineerFeaturesStep {
                     .collect();
 
                 let new_series = Series::new(trig.output_name().as_str().into(), transformed);
-                df = df.with_column(new_series)?.clone();
+                df = df.with_column(new_series.into())?.clone();
             }
         }
 
@@ -495,7 +495,7 @@ impl PipelineStep for EngineerFeaturesStep {
         if !self.interaction_pairs.is_empty() {
             // Convert named pairs to index pairs
             let numeric_cols: Vec<String> = df
-                .get_columns()
+                .columns()
                 .iter()
                 .filter(|col| col.dtype().is_numeric())
                 .map(|col| col.name().to_string())
@@ -521,7 +521,7 @@ impl PipelineStep for EngineerFeaturesStep {
         if !self.ratio_pairs.is_empty() {
             // Convert named pairs to index pairs
             let numeric_cols: Vec<String> = df
-                .get_columns()
+                .columns()
                 .iter()
                 .filter(|col| col.dtype().is_numeric())
                 .map(|col| col.name().to_string())
@@ -1127,7 +1127,7 @@ impl PipelineStep for CustomFeaturesStep {
         for feature in &self.features {
             let values = feature.expr.evaluate(&df)?;
             let series = Series::new(feature.name.as_str().into(), values);
-            df = df.with_column(series)?.clone();
+            df = df.with_column(series.into())?.clone();
         }
         Ok(df)
     }
@@ -1293,7 +1293,7 @@ impl PipelineStep for EncodeCategoricalsStep {
 
         // Identify categorical columns
         let categorical_columns: Vec<String> = df
-            .get_columns()
+            .columns()
             .iter()
             .filter(|col| matches!(col.dtype(), DataType::String | DataType::Categorical(_, _)))
             .map(|col| col.name().to_string())
@@ -1343,7 +1343,7 @@ impl PipelineStep for EncodeCategoricalsStep {
 
             // Replace categorical column with encoded Float64 column
             let encoded_series = Series::new(col_name.as_str().into(), encoded);
-            df.replace(col_name.as_str(), encoded_series)?;
+            df.replace(col_name.as_str(), encoded_series.into())?;
         }
 
         Ok(df)
@@ -1370,7 +1370,7 @@ impl PipelineStep for EncodeCategoricalsStep {
 
                 // Replace with encoded Float64 column
                 let encoded_series = Series::new(col_name.as_str().into(), encoded);
-                df.replace(col_name.as_str(), encoded_series)?;
+                df.replace(col_name.as_str(), encoded_series.into())?;
             }
         }
 
@@ -1529,7 +1529,7 @@ impl PipelineStep for BinNumericFeaturesStep {
         // Actual binning to u8 happens later in DataPipeline
         let binner = QuantileBinner::new(self.num_bins);
 
-        for col in df.get_columns() {
+        for col in df.columns() {
             if col.dtype().is_numeric() {
                 let col_name = col.name().to_string();
                 let values = Self::series_to_f64(col.as_materialized_series())?;

--- a/src/model/pipeline/steps.rs
+++ b/src/model/pipeline/steps.rs
@@ -552,12 +552,12 @@ impl PipelineStep for EngineerFeaturesStep {
     }
 
     fn serialize_state(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(self).map_err(|e| {
+        serde_json::to_value(self).map_err(|e| {
             TreeBoostError::Serialization(format!(
                 "Failed to serialize EngineerFeaturesStep: {}",
                 e
             ))
-        })?)
+        })
     }
 
     fn deserialize_state(&mut self, state: serde_json::Value) -> Result<()> {
@@ -925,6 +925,7 @@ impl FeatureOp {
     }
 
     /// Add two expressions
+    #[allow(clippy::should_implement_trait)] // reason: intentional inherent API, not the std trait
     pub fn add(mut self, other: Self) -> Self {
         let other_root = self.expr.merge(other.expr);
         let new_root = self.expr.push(FlatOp::Add(self.expr.root, other_root));
@@ -933,6 +934,7 @@ impl FeatureOp {
     }
 
     /// Subtract: self - other
+    #[allow(clippy::should_implement_trait)] // reason: intentional inherent API, not the std trait
     pub fn sub(mut self, other: Self) -> Self {
         let other_root = self.expr.merge(other.expr);
         let new_root = self.expr.push(FlatOp::Sub(self.expr.root, other_root));
@@ -941,6 +943,7 @@ impl FeatureOp {
     }
 
     /// Multiply two expressions
+    #[allow(clippy::should_implement_trait)] // reason: intentional inherent API, not the std trait
     pub fn mul(mut self, other: Self) -> Self {
         let other_root = self.expr.merge(other.expr);
         let new_root = self.expr.push(FlatOp::Mul(self.expr.root, other_root));
@@ -949,6 +952,7 @@ impl FeatureOp {
     }
 
     /// Divide: self / other
+    #[allow(clippy::should_implement_trait)] // reason: intentional inherent API, not the std trait
     pub fn div(mut self, other: Self) -> Self {
         let other_root = self.expr.merge(other.expr);
         let new_root = self.expr.push(FlatOp::Div(self.expr.root, other_root));
@@ -1137,9 +1141,9 @@ impl PipelineStep for CustomFeaturesStep {
     }
 
     fn serialize_state(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(self).map_err(|e| {
+        serde_json::to_value(self).map_err(|e| {
             TreeBoostError::Serialization(format!("Failed to serialize CustomFeaturesStep: {}", e))
-        })?)
+        })
     }
 
     fn deserialize_state(&mut self, state: serde_json::Value) -> Result<()> {
@@ -1215,12 +1219,12 @@ impl PipelineStep for EngineerTimeSeriesFeaturesStep {
     }
 
     fn serialize_state(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(self).map_err(|e| {
+        serde_json::to_value(self).map_err(|e| {
             TreeBoostError::Serialization(format!(
                 "Failed to serialize EngineerTimeSeriesFeaturesStep: {}",
                 e
             ))
-        })?)
+        })
     }
 
     fn deserialize_state(&mut self, state: serde_json::Value) -> Result<()> {
@@ -1257,6 +1261,12 @@ pub struct CategoryEncoding {
 #[derive(Clone)]
 pub struct EncodeCategoricalsStep {
     pub encodings: HashMap<String, CategoryEncoding>,
+}
+
+impl Default for EncodeCategoricalsStep {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl EncodeCategoricalsStep {
@@ -1467,9 +1477,9 @@ impl PipelineStep for TransformTargetStep {
     }
 
     fn serialize_state(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(&self.transform).map_err(|e| {
+        serde_json::to_value(&self.transform).map_err(|e| {
             TreeBoostError::Serialization(format!("Failed to serialize TransformTargetStep: {}", e))
-        })?)
+        })
     }
 
     fn deserialize_state(&mut self, state: serde_json::Value) -> Result<()> {
@@ -1631,12 +1641,12 @@ impl PipelineStep for ExtractLinearFeaturesStep {
     }
 
     fn serialize_state(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(self).map_err(|e| {
+        serde_json::to_value(self).map_err(|e| {
             TreeBoostError::Serialization(format!(
                 "Failed to serialize ExtractLinearFeaturesStep: {}",
                 e
             ))
-        })?)
+        })
     }
 
     fn deserialize_state(&mut self, state: serde_json::Value) -> Result<()> {

--- a/src/model/pipeline/steps.rs
+++ b/src/model/pipeline/steps.rs
@@ -452,7 +452,7 @@ impl PipelineStep for EngineerFeaturesStep {
                 let str_chunked = str_series.str()?;
 
                 let mapped: Vec<f64> = str_chunked
-                    .into_iter()
+                    .iter()
                     .map(|opt| lut.get(opt.unwrap_or("")))
                     .collect();
 
@@ -469,7 +469,7 @@ impl PipelineStep for EngineerFeaturesStep {
                 let two_pi = 2.0 * std::f64::consts::PI;
 
                 let transformed: Vec<f64> = values
-                    .into_iter()
+                    .iter()
                     .map(|opt| {
                         let x = opt.unwrap_or(0.0);
                         let angle = two_pi * x / trig.period;
@@ -695,7 +695,7 @@ impl FeatureExpr {
                     let series = df.column(name)?;
                     let casted = series.cast(&DataType::Float64)?;
                     let values = casted.f64()?;
-                    values.into_iter().map(|v| v.unwrap_or(0.0)).collect()
+                    values.iter().map(|v| v.unwrap_or(0.0)).collect()
                 }
                 FlatOp::Const(v) => vec![*v; n],
                 FlatOp::Add(l, r) => {
@@ -730,7 +730,7 @@ impl FeatureExpr {
                     let str_series = series.cast(&DataType::String)?;
                     let str_chunked = str_series.str()?;
                     str_chunked
-                        .into_iter()
+                        .iter()
                         .map(|opt| {
                             let cat = opt.unwrap_or("");
                             mapping
@@ -747,7 +747,7 @@ impl FeatureExpr {
                     let values = casted.f64()?;
                     let two_pi = 2.0 * std::f64::consts::PI;
                     values
-                        .into_iter()
+                        .iter()
                         .map(|v| (two_pi * v.unwrap_or(0.0) / period).sin())
                         .collect()
                 }
@@ -757,7 +757,7 @@ impl FeatureExpr {
                     let values = casted.f64()?;
                     let two_pi = 2.0 * std::f64::consts::PI;
                     values
-                        .into_iter()
+                        .iter()
                         .map(|v| (two_pi * v.unwrap_or(0.0) / period).cos())
                         .collect()
                 }
@@ -766,7 +766,7 @@ impl FeatureExpr {
                     let casted = series.cast(&DataType::Float64)?;
                     let values = casted.f64()?;
                     values
-                        .into_iter()
+                        .iter()
                         .map(|v| (1.0 + v.unwrap_or(0.0)).ln())
                         .collect()
                 }
@@ -775,7 +775,7 @@ impl FeatureExpr {
                     let casted = series.cast(&DataType::Float64)?;
                     let values = casted.f64()?;
                     values
-                        .into_iter()
+                        .iter()
                         .map(|v| {
                             let x = v.unwrap_or(0.0);
                             x * x
@@ -787,7 +787,7 @@ impl FeatureExpr {
                     let casted = series.cast(&DataType::Float64)?;
                     let values = casted.f64()?;
                     values
-                        .into_iter()
+                        .iter()
                         .map(|v| v.unwrap_or(0.0).max(0.0).sqrt())
                         .collect()
                 }
@@ -796,7 +796,7 @@ impl FeatureExpr {
                     let casted = series.cast(&DataType::Float64)?;
                     let values = casted.f64()?;
                     values
-                        .into_iter()
+                        .iter()
                         .map(|v| v.unwrap_or(0.0).powf(*power))
                         .collect()
                 }
@@ -1272,7 +1272,7 @@ impl EncodeCategoricalsStep {
         let str_series = series.cast(&DataType::String)?;
         let str_chunked = str_series.str()?;
         Ok(str_chunked
-            .into_iter()
+            .iter()
             .map(|opt| opt.unwrap_or("").to_string())
             .collect())
     }
@@ -1512,7 +1512,7 @@ impl BinNumericFeaturesStep {
         series
             .cast(&DataType::Float64)?
             .f64()?
-            .into_iter()
+            .iter()
             .map(|opt| Ok(opt.unwrap_or(f64::NAN)))
             .collect()
     }

--- a/src/model/predictor.rs
+++ b/src/model/predictor.rs
@@ -348,7 +348,7 @@ impl GatedPredictor {
         let mut binned = Vec::with_capacity(num_rows * num_features);
         let mut feature_info = Vec::with_capacity(num_features);
 
-        for col in df.get_columns() {
+        for col in df.columns() {
             let col_name = col.name().to_string();
 
             // Extract column values as f32 with proper error handling

--- a/src/model/predictor.rs
+++ b/src/model/predictor.rs
@@ -556,7 +556,7 @@ impl EnsemblePredictor {
             EnsembleStrategy::Median => {
                 let combined: Vec<f64> = (0..n_samples)
                     .map(|i| {
-                        let mut values = vec![formula_preds[i], model_preds[i]];
+                        let mut values = [formula_preds[i], model_preds[i]];
                         values
                             .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
                         (values[0] + values[1]) / 2.0 // Median of 2 = average

--- a/src/model/tuning.rs
+++ b/src/model/tuning.rs
@@ -172,14 +172,11 @@ fn tune_tree_model(
             .with_min_samples_leaf(5)
             .with_seed(42)
             .with_backend(backend_type),
-        TaskType::MultiClassification { num_classes } => {
-            let cfg = GBDTConfig::new()
-                .with_multiclass_logloss(*num_classes)?
-                .with_min_samples_leaf(5)
-                .with_seed(42)
-                .with_backend(backend_type);
-            cfg
-        }
+        TaskType::MultiClassification { num_classes } => GBDTConfig::new()
+            .with_multiclass_logloss(*num_classes)?
+            .with_min_samples_leaf(5)
+            .with_seed(42)
+            .with_backend(backend_type),
     };
 
     // Determine task type:

--- a/src/model/universal/config.rs
+++ b/src/model/universal/config.rs
@@ -402,7 +402,7 @@ impl UniversalConfig {
     }
 
     pub fn with_validation_ratio(mut self, ratio: f32) -> Result<Self> {
-        if ratio < 0.0 || ratio > 0.5 {
+        if !(0.0..=0.5).contains(&ratio) {
             return Err(TreeBoostError::Config(format!(
                 "validation_ratio must be in [0, 0.5], got {}",
                 ratio
@@ -419,13 +419,13 @@ impl UniversalConfig {
 
     /// Enable conformal calibration for uncertainty estimates.
     pub fn with_conformal_calibration(mut self, ratio: f32, quantile: f32) -> Result<Self> {
-        if ratio < 0.0 || ratio > 0.5 {
+        if !(0.0..=0.5).contains(&ratio) {
             return Err(TreeBoostError::Config(format!(
                 "calibration_ratio must be in [0, 0.5], got {}",
                 ratio
             )));
         }
-        if quantile < 0.5 || quantile > 0.99 {
+        if !(0.5..=0.99).contains(&quantile) {
             return Err(TreeBoostError::Config(format!(
                 "conformal_quantile must be in [0.5, 0.99], got {}",
                 quantile

--- a/src/model/universal/core.rs
+++ b/src/model/universal/core.rs
@@ -282,11 +282,10 @@ impl UniversalModel {
             .clone()
             .unwrap_or_else(|| Self::extract_raw_features(dataset));
 
-        let num_raw_features = if num_rows > 0 {
-            raw_features.len() / num_rows
-        } else {
-            self.num_features
-        };
+        let num_raw_features = raw_features
+            .len()
+            .checked_div(num_rows)
+            .unwrap_or(self.num_features);
 
         // Extract selected features if feature selection was used
         let linear_features = crate::features::extract_selected_features(
@@ -357,8 +356,8 @@ impl UniversalModel {
 
             // Add intercept if present (Ridge stacking)
             if let Some(intercept) = self.stacker_intercept {
-                for i in 0..num_rows {
-                    combined[i] += intercept;
+                for value in combined.iter_mut() {
+                    *value += intercept;
                 }
             }
 
@@ -381,6 +380,7 @@ impl UniversalModel {
     /// Train multi-seed GBDT ensemble and fit stacker
     ///
     /// Returns (None, Some(ensemble), Some(weights), Some(intercept))
+    #[allow(clippy::type_complexity)] // reason: complex return tuple kept inline
     pub(super) fn train_gbdt_ensemble(
         dataset: &BinnedDataset,
         config: &UniversalConfig,

--- a/src/model/universal/incremental.rs
+++ b/src/model/universal/incremental.rs
@@ -217,7 +217,7 @@ impl UniversalModel {
                 // Bootstrap sample
                 let bootstrap_indices: Vec<usize> = (0..num_rows)
                     .map(|_| {
-                        use rand::Rng;
+                        use rand::RngExt;
                         rng.random_range(0..num_rows)
                     })
                     .collect();

--- a/src/model/universal/prediction.rs
+++ b/src/model/universal/prediction.rs
@@ -56,11 +56,10 @@ impl UniversalModel {
                         .unwrap_or_else(|| Self::extract_raw_features(dataset));
 
                     // Calculate actual number of raw features from array size
-                    let num_raw_features = if num_rows > 0 {
-                        raw_features_full.len() / num_rows
-                    } else {
-                        self.num_features // Fallback
-                    };
+                    let num_raw_features = raw_features_full
+                        .len()
+                        .checked_div(num_rows)
+                        .unwrap_or(self.num_features); // Fallback
 
                     // Filter features for linear model if indices are specified
                     let (raw_features, num_linear_features) =
@@ -175,11 +174,10 @@ impl UniversalModel {
                 if let Some(ref linear) = self.linear_booster {
                     // Calculate actual number of features in raw_features array
                     // (may differ from self.num_features if FeatureExtractor was used)
-                    let num_raw_features = if num_rows > 0 {
-                        raw_features.len() / num_rows
-                    } else {
-                        self.num_features
-                    };
+                    let num_raw_features = raw_features
+                        .len()
+                        .checked_div(num_rows)
+                        .unwrap_or(self.num_features);
 
                     let num_lin_feats = self.num_linear_features.unwrap_or(num_raw_features);
 
@@ -251,11 +249,10 @@ impl UniversalModel {
 
         // Add only linear contribution (no trees)
         if let Some(ref linear) = self.linear_booster {
-            let num_raw_features = if num_rows > 0 {
-                raw_features.len() / num_rows
-            } else {
-                self.num_features
-            };
+            let num_raw_features = raw_features
+                .len()
+                .checked_div(num_rows)
+                .unwrap_or(self.num_features);
 
             let num_lin_feats = self.num_linear_features.unwrap_or(num_raw_features);
 
@@ -747,11 +744,7 @@ impl UniversalModel {
             let num_outputs = linear_boosters.len();
 
             // Get base predictions per label
-            let base_preds = self
-                .base_predictions_multi
-                .as_ref()
-                .map(|v| v.as_slice())
-                .unwrap_or(&[]);
+            let base_preds = self.base_predictions_multi.as_deref().unwrap_or(&[]);
 
             // Get raw features from dataset (packed during pipeline processing)
             let raw_features_full = dataset
@@ -760,11 +753,10 @@ impl UniversalModel {
                 .unwrap_or_else(|| Self::extract_raw_features(dataset));
 
             // Calculate actual number of raw features from array size
-            let num_raw_feats_total = if num_rows > 0 {
-                raw_features_full.len() / num_rows
-            } else {
-                self.num_features // Fallback
-            };
+            let num_raw_feats_total = raw_features_full
+                .len()
+                .checked_div(num_rows)
+                .unwrap_or(self.num_features); // Fallback
 
             // Filter features for linear model if indices are specified
             let (raw_features, num_raw_features) =
@@ -804,7 +796,7 @@ impl UniversalModel {
                 vec![vec![0.0; num_rows]; num_outputs]
             };
 
-            for i in 0..num_rows {
+            for (i, row_predictions) in predictions.iter_mut().enumerate() {
                 for k in 0..num_outputs {
                     // Base prediction for this label
                     let base = base_preds.get(k).copied().unwrap_or(0.0);
@@ -820,7 +812,7 @@ impl UniversalModel {
                         .copied()
                         .unwrap_or(0.0);
 
-                    predictions[i][k] = base + shrinkage * linear_pred + tree_contrib;
+                    row_predictions[k] = base + shrinkage * linear_pred + tree_contrib;
                 }
             }
 

--- a/src/model/universal/serialization.rs
+++ b/src/model/universal/serialization.rs
@@ -318,10 +318,10 @@ mod tests {
 
         let batch_preds = model.predict(&dataset);
 
-        for row_idx in 0..dataset.num_rows().min(10) {
+        for (row_idx, &batch_pred) in batch_preds.iter().take(10).enumerate() {
             let single_pred = model.predict_row(&dataset, row_idx);
             assert!(
-                (single_pred - batch_preds[row_idx]).abs() < 1e-5,
+                (single_pred - batch_pred).abs() < 1e-5,
                 "Single-row and batch predictions should match"
             );
         }

--- a/src/model/universal/training.rs
+++ b/src/model/universal/training.rs
@@ -528,6 +528,8 @@ impl UniversalModel {
     //
     // See: AutoBuilder::train_ltt_ensemble() in src/model/builder.rs for the other copy.
 
+    // reason: kernel/training entry point with many parameters
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn train_linear_then_tree(
         dataset: &BinnedDataset,
         raw_features_opt: Option<&[f32]>,
@@ -589,11 +591,10 @@ impl UniversalModel {
 
         // Calculate actual number of features in raw_features
         // (may differ from num_features if FeatureExtractor was used)
-        let num_raw_features = if num_rows > 0 {
-            raw_features.len() / num_rows
-        } else {
-            num_features
-        };
+        let num_raw_features = raw_features
+            .len()
+            .checked_div(num_rows)
+            .unwrap_or(num_features);
 
         // Determine number of features for linear model
         let num_linear_features = linear_indices
@@ -884,11 +885,10 @@ impl UniversalModel {
 
         // Extract raw features for linear models
         let raw_features = Self::extract_raw_features(dataset);
-        let num_raw_features = if num_rows > 0 {
-            raw_features.len() / num_rows
-        } else {
-            num_features
-        };
+        let num_raw_features = raw_features
+            .len()
+            .checked_div(num_rows)
+            .unwrap_or(num_features);
 
         // =====================================================================
         // Phase 1: Fit N LinearBoosters (one per label)

--- a/src/model/universal/training.rs
+++ b/src/model/universal/training.rs
@@ -777,7 +777,7 @@ impl UniversalModel {
                 let mut rng = rand::rngs::StdRng::seed_from_u64(config.seed + seed_offset as u64);
                 let bootstrap_indices: Vec<usize> = (0..num_rows)
                     .map(|_| {
-                        use rand::Rng;
+                        use rand::RngExt;
                         rng.random_range(0..num_rows)
                     })
                     .collect();

--- a/src/monitoring/detector.rs
+++ b/src/monitoring/detector.rs
@@ -170,11 +170,7 @@ impl ShiftDetector {
         num_features: usize,
         feature_names: Option<&[String]>,
     ) -> Self {
-        let num_rows = if num_features > 0 {
-            features.len() / num_features
-        } else {
-            0
-        };
+        let num_rows = features.len().checked_div(num_features).unwrap_or(0);
 
         // For raw data without binning info, use MAX_HISTOGRAM_BINS as default
         let bins_per_feature = vec![MAX_HISTOGRAM_BINS; num_features];

--- a/src/monitoring/incremental.rs
+++ b/src/monitoring/incremental.rs
@@ -301,7 +301,7 @@ impl DriftHistory {
 
         // Sort by frequency
         self.frequently_drifted_features
-            .sort_by(|a, b| b.1.cmp(&a.1));
+            .sort_by_key(|b| std::cmp::Reverse(b.1));
     }
 
     /// Get drift rate (fraction of updates with drift)

--- a/src/preprocessing/dataframe.rs
+++ b/src/preprocessing/dataframe.rs
@@ -148,7 +148,7 @@ fn apply_scaler_impl<S: Scaler + Clone>(
             .as_materialized_series()
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect::<Vec<f32>>();
         columns.push(col);
@@ -229,7 +229,7 @@ pub fn apply_frequency_encoder(
         let str_series = col.as_materialized_series().str()?;
 
         // Collect categories
-        let categories: Vec<&str> = str_series.into_iter().map(|v| v.unwrap_or("")).collect();
+        let categories: Vec<&str> = str_series.iter().map(|v| v.unwrap_or("")).collect();
 
         // Fit if not fitted
         if !encoder.is_fitted() {
@@ -284,7 +284,7 @@ pub fn apply_label_encoder(
         let str_series = col.as_materialized_series().str()?;
 
         // Collect categories
-        let categories: Vec<&str> = str_series.into_iter().map(|v| v.unwrap_or("")).collect();
+        let categories: Vec<&str> = str_series.iter().map(|v| v.unwrap_or("")).collect();
 
         // Fit if not fitted
         if !encoder.is_fitted() {
@@ -340,7 +340,7 @@ pub fn apply_onehot_encoder(
         let str_series = col.as_materialized_series().str()?;
 
         // Collect categories
-        let categories: Vec<&str> = str_series.into_iter().map(|v| v.unwrap_or("")).collect();
+        let categories: Vec<&str> = str_series.iter().map(|v| v.unwrap_or("")).collect();
 
         // Fit if not fitted
         if !encoder.is_fitted() {
@@ -443,7 +443,7 @@ pub fn apply_simple_imputer(
             .as_materialized_series()
             .cast(&DataType::Float32)?
             .f32()?
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(f32::NAN))
             .collect::<Vec<f32>>();
         columns.push(col);

--- a/src/preprocessing/dataframe.rs
+++ b/src/preprocessing/dataframe.rs
@@ -128,7 +128,7 @@ fn apply_scaler_impl<S: Scaler + Clone>(
         // Auto-detect numeric columns
         df.columns()
             .iter()
-            .filter(|col| is_numeric(*col))
+            .filter(|col| is_numeric(col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -157,8 +157,8 @@ fn apply_scaler_impl<S: Scaler + Clone>(
     // Interleave to row-major format
     let mut feature_data: Vec<f32> = Vec::with_capacity(num_rows * num_features);
     for row_idx in 0..num_rows {
-        for col_idx in 0..num_features {
-            feature_data.push(columns[col_idx][row_idx]);
+        for col in &columns {
+            feature_data.push(col[row_idx]);
         }
     }
 
@@ -222,7 +222,7 @@ pub fn apply_frequency_encoder(
     columns: Vec<String>,
     fitted_encoder: Option<FrequencyEncoder>,
 ) -> Result<(DataFrame, FrequencyEncoder)> {
-    let mut encoder = fitted_encoder.unwrap_or_else(FrequencyEncoder::new);
+    let mut encoder = fitted_encoder.unwrap_or_default();
 
     for col_name in &columns {
         let col = df.column(col_name)?;
@@ -277,7 +277,7 @@ pub fn apply_label_encoder(
     columns: Vec<String>,
     fitted_encoder: Option<LabelEncoder>,
 ) -> Result<(DataFrame, LabelEncoder)> {
-    let mut encoder = fitted_encoder.unwrap_or_else(LabelEncoder::new);
+    let mut encoder = fitted_encoder.unwrap_or_default();
 
     for col_name in &columns {
         let col = df.column(col_name)?;
@@ -333,7 +333,7 @@ pub fn apply_onehot_encoder(
     columns: Vec<String>,
     fitted_encoder: Option<OneHotEncoder>,
 ) -> Result<(DataFrame, OneHotEncoder)> {
-    let mut encoder = fitted_encoder.unwrap_or_else(OneHotEncoder::new);
+    let mut encoder = fitted_encoder.unwrap_or_default();
 
     for col_name in &columns {
         let col = df.column(col_name)?;
@@ -424,7 +424,7 @@ pub fn apply_simple_imputer(
         // Auto-detect numeric columns
         df.columns()
             .iter()
-            .filter(|col| is_numeric(*col))
+            .filter(|col| is_numeric(col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -452,8 +452,8 @@ pub fn apply_simple_imputer(
     // Interleave to row-major format
     let mut feature_data: Vec<f32> = Vec::with_capacity(num_rows * num_features);
     for row_idx in 0..num_rows {
-        for col_idx in 0..num_features {
-            feature_data.push(columns[col_idx][row_idx]);
+        for col in &columns {
+            feature_data.push(col[row_idx]);
         }
     }
 

--- a/src/preprocessing/dataframe.rs
+++ b/src/preprocessing/dataframe.rs
@@ -126,9 +126,9 @@ fn apply_scaler_impl<S: Scaler + Clone>(
         cols
     } else {
         // Auto-detect numeric columns
-        df.get_columns()
+        df.columns()
             .iter()
-            .filter(|col| is_numeric(col))
+            .filter(|col| is_numeric(*col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -182,7 +182,7 @@ fn apply_scaler_impl<S: Scaler + Clone>(
 
     // Replace columns in original DataFrame
     for series in new_columns {
-        df.replace(&series.name().to_string(), series)?;
+        df.replace(&series.name().to_string(), series.into())?;
     }
 
     Ok((df, scaler))
@@ -241,7 +241,7 @@ pub fn apply_frequency_encoder(
 
         // Replace column
         let new_series = Series::new(col_name.clone().into(), encoded);
-        df.replace(col_name, new_series)?;
+        df.replace(col_name, new_series.into())?;
     }
 
     Ok((df, encoder))
@@ -296,7 +296,7 @@ pub fn apply_label_encoder(
 
         // Replace column with u32
         let new_series = Series::new(col_name.clone().into(), encoded);
-        df.replace(col_name, new_series)?;
+        df.replace(col_name, new_series.into())?;
     }
 
     Ok((df, encoder))
@@ -422,9 +422,9 @@ pub fn apply_simple_imputer(
         cols
     } else {
         // Auto-detect numeric columns
-        df.get_columns()
+        df.columns()
             .iter()
-            .filter(|col| is_numeric(col))
+            .filter(|col| is_numeric(*col))
             .map(|col| col.name().to_string())
             .collect()
     };
@@ -477,7 +477,7 @@ pub fn apply_simple_imputer(
 
     // Replace columns
     for series in new_columns {
-        df.replace(&series.name().to_string(), series)?;
+        df.replace(&series.name().to_string(), series.into())?;
     }
 
     Ok((df, imputer))

--- a/src/preprocessing/outliers.rs
+++ b/src/preprocessing/outliers.rs
@@ -780,7 +780,7 @@ mod tests {
             assert_eq!(indicator_names[1], "f1_outlier");
 
             // Row 4, feature 0 should be flagged
-            assert!((indicators[4 * 2 + 0] - 1.0).abs() < 1e-6);
+            assert!((indicators[4 * 2] - 1.0).abs() < 1e-6);
             // Row 4, feature 1 should not be flagged
             assert!((indicators[4 * 2 + 1] - 0.0).abs() < 1e-6);
         } else {

--- a/src/preprocessing/polars_ext.rs
+++ b/src/preprocessing/polars_ext.rs
@@ -75,10 +75,7 @@ pub fn column_to_strings(column: &Column) -> Result<Vec<String>, TreeBoostError>
         .str()
         .map_err(|e| TreeBoostError::Data(format!("Cannot get str ChunkedArray: {}", e)))?;
 
-    Ok(ca
-        .iter()
-        .map(|opt| opt.unwrap_or("").to_string())
-        .collect())
+    Ok(ca.iter().map(|opt| opt.unwrap_or("").to_string()).collect())
 }
 
 /// Convert a Polars Series to `Vec<f32>`
@@ -349,10 +346,13 @@ mod tests {
 
     #[test]
     fn test_df_to_features() {
-        let df = DataFrame::new(3, vec![
-            Series::new("a".into(), vec![1.0f64, 2.0, 3.0]).into(),
-            Series::new("b".into(), vec![4.0f64, 5.0, 6.0]).into(),
-        ])
+        let df = DataFrame::new(
+            3,
+            vec![
+                Series::new("a".into(), vec![1.0f64, 2.0, 3.0]).into(),
+                Series::new("b".into(), vec![4.0f64, 5.0, 6.0]).into(),
+            ],
+        )
         .unwrap();
 
         let (data, num_features) = df_to_features(&df, &["a", "b"]).unwrap();
@@ -378,10 +378,13 @@ mod tests {
 
     #[test]
     fn test_df_to_target() {
-        let df = DataFrame::new(2, vec![
-            Series::new("feature".into(), vec![1.0f64, 2.0]).into(),
-            Series::new("target".into(), vec![10.0f64, 20.0]).into(),
-        ])
+        let df = DataFrame::new(
+            2,
+            vec![
+                Series::new("feature".into(), vec![1.0f64, 2.0]).into(),
+                Series::new("target".into(), vec![10.0f64, 20.0]).into(),
+            ],
+        )
         .unwrap();
 
         let target = df_to_target(&df, "target").unwrap();
@@ -390,12 +393,15 @@ mod tests {
 
     #[test]
     fn test_split_by_dtype() {
-        let df = DataFrame::new(2, vec![
-            Series::new("num1".into(), vec![1.0f64, 2.0]).into(),
-            Series::new("num2".into(), vec![3i32, 4]).into(),
-            Series::new("cat1".into(), vec!["a", "b"]).into(),
-            Series::new("target".into(), vec![1.0f64, 2.0]).into(),
-        ])
+        let df = DataFrame::new(
+            2,
+            vec![
+                Series::new("num1".into(), vec![1.0f64, 2.0]).into(),
+                Series::new("num2".into(), vec![3i32, 4]).into(),
+                Series::new("cat1".into(), vec!["a", "b"]).into(),
+                Series::new("target".into(), vec![1.0f64, 2.0]).into(),
+            ],
+        )
         .unwrap();
 
         let (numeric, categorical) = split_by_dtype(&df, &["target"]);
@@ -429,10 +435,13 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         // DataFrame -> features -> DataFrame roundtrip
-        let original = DataFrame::new(3, vec![
-            Series::new("x".into(), vec![1.0f64, 2.0, 3.0]).into(),
-            Series::new("y".into(), vec![4.0f64, 5.0, 6.0]).into(),
-        ])
+        let original = DataFrame::new(
+            3,
+            vec![
+                Series::new("x".into(), vec![1.0f64, 2.0, 3.0]).into(),
+                Series::new("y".into(), vec![4.0f64, 5.0, 6.0]).into(),
+            ],
+        )
         .unwrap();
 
         let (data, num_features) = df_to_features(&original, &["x", "y"]).unwrap();

--- a/src/preprocessing/polars_ext.rs
+++ b/src/preprocessing/polars_ext.rs
@@ -211,7 +211,7 @@ pub fn features_to_df(
         })
         .collect();
 
-    DataFrame::new(columns)
+    DataFrame::new_infer_height(columns)
         .map_err(|e| TreeBoostError::Data(format!("Failed to create DataFrame: {}", e)))
 }
 
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_df_to_features() {
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(3, vec![
             Series::new("a".into(), vec![1.0f64, 2.0, 3.0]).into(),
             Series::new("b".into(), vec![4.0f64, 5.0, 6.0]).into(),
         ])
@@ -378,7 +378,7 @@ mod tests {
 
     #[test]
     fn test_df_to_target() {
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(2, vec![
             Series::new("feature".into(), vec![1.0f64, 2.0]).into(),
             Series::new("target".into(), vec![10.0f64, 20.0]).into(),
         ])
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_split_by_dtype() {
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(2, vec![
             Series::new("num1".into(), vec![1.0f64, 2.0]).into(),
             Series::new("num2".into(), vec![3i32, 4]).into(),
             Series::new("cat1".into(), vec!["a", "b"]).into(),
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn test_roundtrip() {
         // DataFrame -> features -> DataFrame roundtrip
-        let original = DataFrame::new(vec![
+        let original = DataFrame::new(3, vec![
             Series::new("x".into(), vec![1.0f64, 2.0, 3.0]).into(),
             Series::new("y".into(), vec![4.0f64, 5.0, 6.0]).into(),
         ])

--- a/src/preprocessing/polars_ext.rs
+++ b/src/preprocessing/polars_ext.rs
@@ -49,7 +49,7 @@ pub fn column_to_f32(column: &Column) -> Result<Vec<f32>, TreeBoostError> {
         .map_err(|e| TreeBoostError::Data(format!("Cannot get f64 ChunkedArray: {}", e)))?;
 
     Ok(ca
-        .into_iter()
+        .iter()
         .map(|opt| opt.map(|v| v as f32).unwrap_or(f32::NAN))
         .collect())
 }
@@ -76,7 +76,7 @@ pub fn column_to_strings(column: &Column) -> Result<Vec<String>, TreeBoostError>
         .map_err(|e| TreeBoostError::Data(format!("Cannot get str ChunkedArray: {}", e)))?;
 
     Ok(ca
-        .into_iter()
+        .iter()
         .map(|opt| opt.unwrap_or("").to_string())
         .collect())
 }

--- a/src/preprocessing/scaler.rs
+++ b/src/preprocessing/scaler.rs
@@ -324,8 +324,7 @@ impl StandardScaler {
             self.stds = vec![1.0; num_features];
             self.welford_states = vec![WelfordState::new(); num_features];
 
-            for feat in 0..num_features {
-                let (mean, var) = batch_stats[feat];
+            for (feat, &(mean, var)) in batch_stats.iter().enumerate() {
                 self.means[feat] = mean as f32;
                 let std = var.sqrt() as f32;
                 self.stds[feat] = if std < 1e-8 { 1.0 } else { std };
@@ -353,9 +352,7 @@ impl StandardScaler {
         let alpha_64 = alpha as f64;
         let decay = 1.0 - alpha_64;
 
-        for feat in 0..num_features {
-            let (batch_mean, batch_var) = batch_stats[feat];
-
+        for (feat, &(batch_mean, batch_var)) in batch_stats.iter().enumerate() {
             // Update mean via EMA
             let old_mean = self.means[feat] as f64;
             let new_mean = decay * old_mean + alpha_64 * batch_mean;

--- a/src/preprocessing/smart.rs
+++ b/src/preprocessing/smart.rs
@@ -689,13 +689,16 @@ mod tests {
     use polars::prelude::*;
 
     fn create_test_profile() -> DataFrameProfile {
-        let df = DataFrame::new(5, vec![
-            Series::new("numeric_normal".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
-            Series::new("numeric_skewed".into(), vec![1.0f64, 1.0, 1.0, 10.0, 100.0]).into(),
-            Series::new("categorical_low".into(), vec!["A", "B", "A", "B", "A"]).into(),
-            Series::new("constant".into(), vec![1.0f64, 1.0, 1.0, 1.0, 1.0]).into(),
-            Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
-        ])
+        let df = DataFrame::new(
+            5,
+            vec![
+                Series::new("numeric_normal".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
+                Series::new("numeric_skewed".into(), vec![1.0f64, 1.0, 1.0, 10.0, 100.0]).into(),
+                Series::new("categorical_low".into(), vec!["A", "B", "A", "B", "A"]).into(),
+                Series::new("constant".into(), vec![1.0f64, 1.0, 1.0, 1.0, 1.0]).into(),
+                Series::new("target".into(), vec![0.0f64, 1.0, 0.0, 1.0, 0.0]).into(),
+            ],
+        )
         .unwrap();
 
         DataFrameProfile::analyze(&df, "target").unwrap()

--- a/src/preprocessing/smart.rs
+++ b/src/preprocessing/smart.rs
@@ -689,7 +689,7 @@ mod tests {
     use polars::prelude::*;
 
     fn create_test_profile() -> DataFrameProfile {
-        let df = DataFrame::new(vec![
+        let df = DataFrame::new(5, vec![
             Series::new("numeric_normal".into(), vec![1.0f64, 2.0, 3.0, 4.0, 5.0]).into(),
             Series::new("numeric_skewed".into(), vec![1.0f64, 1.0, 1.0, 10.0, 100.0]).into(),
             Series::new("categorical_low".into(), vec!["A", "B", "A", "B", "A"]).into(),

--- a/src/python/bindings.rs
+++ b/src/python/bindings.rs
@@ -1085,7 +1085,7 @@ impl PyGBDTModel {
         // Train model using high-level Rust API (release GIL during training)
         // Binning is now done in Rust with Rayon parallelization
         let model = py
-            .allow_threads(|| {
+            .detach(|| {
                 GBDTModel::train(
                     &features_flat,
                     num_features,
@@ -1172,7 +1172,7 @@ impl PyGBDTModel {
 
         // Train model using high-level Rust API (release GIL during training)
         let model = py
-            .allow_threads(|| {
+            .detach(|| {
                 GBDTModel::train_with_eras(
                     &features_flat,
                     num_features,
@@ -1205,7 +1205,7 @@ impl PyGBDTModel {
         validate_feature_count(num_features, self.model.num_features())?;
 
         // Predict using raw values (release GIL)
-        let predictions = py.allow_threads(|| self.model.predict_raw(&raw_features));
+        let predictions = py.detach(|| self.model.predict_raw(&raw_features));
 
         Ok(PyArray1::from_vec(py, predictions))
     }
@@ -1233,7 +1233,7 @@ impl PyGBDTModel {
 
         // Predict with intervals (release GIL)
         let (preds, lower, upper) =
-            py.allow_threads(|| self.model.predict_raw_with_intervals(&raw_features));
+            py.detach(|| self.model.predict_raw_with_intervals(&raw_features));
 
         Ok((
             PyArray1::from_vec(py, preds),
@@ -1274,7 +1274,7 @@ impl PyGBDTModel {
         }
 
         // Predict probabilities (release GIL)
-        let proba = py.allow_threads(|| self.model.predict_proba_raw(&raw_features));
+        let proba = py.detach(|| self.model.predict_proba_raw(&raw_features));
 
         Ok(PyArray1::from_vec(py, proba))
     }
@@ -1313,7 +1313,7 @@ impl PyGBDTModel {
         }
 
         // Predict classes (release GIL)
-        let classes = py.allow_threads(|| self.model.predict_class_raw(&raw_features, threshold));
+        let classes = py.detach(|| self.model.predict_class_raw(&raw_features, threshold));
 
         Ok(PyArray1::from_vec(py, classes))
     }
@@ -1366,7 +1366,7 @@ impl PyGBDTModel {
         }
 
         // Use the raw prediction method (no binning needed, release GIL)
-        let proba = py.allow_threads(|| self.model.predict_proba_multiclass_raw(&raw_features));
+        let proba = py.detach(|| self.model.predict_proba_multiclass_raw(&raw_features));
 
         // Validate array is not jagged before conversion
         if proba.is_empty() {
@@ -1416,7 +1416,7 @@ impl PyGBDTModel {
         }
 
         // Use the raw prediction method (no binning needed, release GIL)
-        let classes = py.allow_threads(|| self.model.predict_class_multiclass_raw(&raw_features));
+        let classes = py.detach(|| self.model.predict_class_multiclass_raw(&raw_features));
 
         Ok(PyArray1::from_vec(py, classes))
     }

--- a/src/python/bindings.rs
+++ b/src/python/bindings.rs
@@ -105,7 +105,7 @@ fn parse_model_format(format: &str) -> PyResult<ModelFormat> {
 /// ]
 /// config = config.with_monotonic_constraints(constraints)
 /// ```
-#[pyclass(name = "MonotonicConstraint", eq)]
+#[pyclass(from_py_object, name = "MonotonicConstraint", eq)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PyMonotonicConstraint {
     inner: MonotonicConstraint,
@@ -156,6 +156,7 @@ impl PyMonotonicConstraint {
     }
 
     /// Convert to integer value (1 = increasing, -1 = decreasing, 0 = none)
+    #[allow(clippy::wrong_self_convention)] // reason: name fixed by Python API
     fn to_int(&self) -> i32 {
         match self.inner {
             MonotonicConstraint::Increasing => 1,
@@ -186,7 +187,7 @@ impl From<PyMonotonicConstraint> for MonotonicConstraint {
 }
 
 /// Python wrapper for GBDT training configuration
-#[pyclass(name = "GBDTConfig")]
+#[pyclass(from_py_object, name = "GBDTConfig")]
 #[derive(Clone)]
 pub struct PyGBDTConfig {
     inner: GBDTConfig,
@@ -808,7 +809,7 @@ impl PyGBDTConfig {
 
     /// Set number of histogram bins
     fn with_num_bins(&self, value: usize) -> PyResult<Self> {
-        if value < 2 || value > 255 {
+        if !(2..=255).contains(&value) {
             return Err(PyValueError::new_err("num_bins must be in [2, 255]"));
         }
         let mut new = self.clone();
@@ -818,7 +819,7 @@ impl PyGBDTConfig {
 
     /// Set calibration set ratio for conformal prediction (0.0 to disable)
     fn with_calibration_ratio(&self, value: f32) -> PyResult<Self> {
-        if value < 0.0 || value >= 1.0 {
+        if !(0.0..1.0).contains(&value) {
             return Err(PyValueError::new_err(
                 "calibration_ratio must be in [0.0, 1.0)",
             ));
@@ -849,7 +850,7 @@ impl PyGBDTConfig {
 
     /// Set validation ratio for early stopping (0.0 to disable)
     fn with_validation_ratio(&self, value: f32) -> PyResult<Self> {
-        if value < 0.0 || value >= 1.0 {
+        if !(0.0..1.0).contains(&value) {
             return Err(PyValueError::new_err(
                 "validation_ratio must be in [0.0, 1.0)",
             ));
@@ -1219,6 +1220,7 @@ impl PyGBDTModel {
     /// Returns:
     ///     Tuple of (predictions, lower_bounds, upper_bounds) as numpy arrays
     #[pyo3(signature = (features))]
+    #[allow(clippy::type_complexity)] // reason: complex return tuple kept inline
     fn predict_with_intervals<'py>(
         &self,
         py: Python<'py>,

--- a/src/python/dataset/loader.rs
+++ b/src/python/dataset/loader.rs
@@ -83,7 +83,7 @@ impl PyDatasetLoader {
             .map(|v| v.iter().map(|s| s.as_str()).collect());
 
         let result =
-            py.allow_threads(|| self.inner.load_csv(path, target, feature_refs.as_deref()));
+            py.detach(|| self.inner.load_csv(path, target, feature_refs.as_deref()));
 
         match result {
             Ok(dataset) => Ok(PyBinnedDataset::from(dataset)),
@@ -115,7 +115,7 @@ impl PyDatasetLoader {
             .as_ref()
             .map(|v| v.iter().map(|s| s.as_str()).collect());
 
-        let result = py.allow_threads(|| {
+        let result = py.detach(|| {
             self.inner
                 .load_parquet(path, target, feature_refs.as_deref())
         });
@@ -233,7 +233,7 @@ impl PyDatasetLoader {
     ) -> PyResult<PyBinnedDataset> {
         let info_vec: Vec<FeatureInfo> = feature_info.into_iter().map(|fi| fi.into()).collect();
 
-        let result = py.allow_threads(|| self.inner.load_csv_for_prediction(path, &info_vec));
+        let result = py.detach(|| self.inner.load_csv_for_prediction(path, &info_vec));
 
         match result {
             Ok(dataset) => Ok(PyBinnedDataset::from(dataset)),
@@ -262,7 +262,7 @@ impl PyDatasetLoader {
     ) -> PyResult<PyBinnedDataset> {
         let info_vec: Vec<FeatureInfo> = feature_info.into_iter().map(|fi| fi.into()).collect();
 
-        let result = py.allow_threads(|| self.inner.load_parquet_for_prediction(path, &info_vec));
+        let result = py.detach(|| self.inner.load_parquet_for_prediction(path, &info_vec));
 
         match result {
             Ok(dataset) => Ok(PyBinnedDataset::from(dataset)),

--- a/src/python/dataset/loader.rs
+++ b/src/python/dataset/loader.rs
@@ -82,8 +82,7 @@ impl PyDatasetLoader {
             .as_ref()
             .map(|v| v.iter().map(|s| s.as_str()).collect());
 
-        let result =
-            py.detach(|| self.inner.load_csv(path, target, feature_refs.as_deref()));
+        let result = py.detach(|| self.inner.load_csv(path, target, feature_refs.as_deref()));
 
         match result {
             Ok(dataset) => Ok(PyBinnedDataset::from(dataset)),
@@ -139,6 +138,7 @@ impl PyDatasetLoader {
     /// Returns:
     ///     BinnedDataset with quantile-binned features
     #[pyo3(signature = (features, targets, feature_names=None))]
+    #[allow(clippy::wrong_self_convention)] // reason: name fixed by Python API
     fn from_numpy<'py>(
         &self,
         features: PyReadonlyArray2<'py, f64>,
@@ -182,18 +182,19 @@ impl PyDatasetLoader {
         let mut all_binned: Vec<Vec<u8>> = Vec::with_capacity(num_features);
         let mut all_info: Vec<FeatureInfo> = Vec::with_capacity(num_features);
 
-        for f in 0..num_features {
+        for (f, name) in names.iter().enumerate() {
             // Extract column
             let col: Vec<f64> = features_arr.column(f).to_vec();
 
-            let (binned, info) = binner
-                .process_numeric_column(names[f].clone(), &col)
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to process column '{}': {}",
-                        names[f], e
-                    ))
-                })?;
+            let (binned, info) =
+                binner
+                    .process_numeric_column(name.clone(), &col)
+                    .map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "Failed to process column '{}': {}",
+                            names[f], e
+                        ))
+                    })?;
 
             all_binned.push(binned);
             all_info.push(info);

--- a/src/python/dataset/pipeline.rs
+++ b/src/python/dataset/pipeline.rs
@@ -286,13 +286,13 @@ impl PyDataPipeline {
             .as_ref()
             .map(|v| v.iter().map(|s| s.as_str()).collect());
 
-        let result = py.allow_threads(|| {
+        let result = py.detach(|| {
             self.inner
                 .load_csv_for_training(path, target, cat_refs.as_deref())
         });
 
         match result {
-            Ok((dataset, state)) => {
+            Ok((dataset, state, _)) => {
                 Ok((PyBinnedDataset::from(dataset), PyPipelineState::from(state)))
             }
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -329,13 +329,13 @@ impl PyDataPipeline {
             .as_ref()
             .map(|v| v.iter().map(|s| s.as_str()).collect());
 
-        let result = py.allow_threads(|| {
+        let result = py.detach(|| {
             self.inner
                 .load_parquet_for_training(path, target, cat_refs.as_deref())
         });
 
         match result {
-            Ok((dataset, state)) => {
+            Ok((dataset, state, _)) => {
                 Ok((PyBinnedDataset::from(dataset), PyPipelineState::from(state)))
             }
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
@@ -361,7 +361,7 @@ impl PyDataPipeline {
         path: &str,
         state: &PyPipelineState,
     ) -> PyResult<PyBinnedDataset> {
-        let result = py.allow_threads(|| self.inner.load_csv_for_inference(path, &state.inner));
+        let result = py.detach(|| self.inner.load_csv_for_inference(path, &state.inner));
 
         match result {
             Ok(dataset) => Ok(PyBinnedDataset::from(dataset)),
@@ -388,7 +388,7 @@ impl PyDataPipeline {
         path: &str,
         state: &PyPipelineState,
     ) -> PyResult<PyBinnedDataset> {
-        let result = py.allow_threads(|| self.inner.load_parquet_for_inference(path, &state.inner));
+        let result = py.detach(|| self.inner.load_parquet_for_inference(path, &state.inner));
 
         match result {
             Ok(dataset) => Ok(PyBinnedDataset::from(dataset)),

--- a/src/python/dataset/pipeline.rs
+++ b/src/python/dataset/pipeline.rs
@@ -26,7 +26,7 @@ use super::types::{PyBinnedDataset, PyFeatureInfo};
 ///     .with_smoothing(10.0)
 /// )
 /// ```
-#[pyclass(name = "PipelineConfig")]
+#[pyclass(from_py_object, name = "PipelineConfig")]
 #[derive(Clone)]
 pub struct PyPipelineConfig {
     pub(crate) inner: PipelineConfig,
@@ -154,7 +154,7 @@ impl PyPipelineConfig {
 ///
 /// Learned state from training that is needed for inference.
 /// Can be serialized and loaded for production deployment.
-#[pyclass(name = "PipelineState")]
+#[pyclass(from_py_object, name = "PipelineState")]
 #[derive(Clone)]
 pub struct PyPipelineState {
     pub(crate) inner: PipelineState,

--- a/src/python/dataset/splits.rs
+++ b/src/python/dataset/splits.rs
@@ -156,7 +156,8 @@ impl PyKFoldSplit {
         }
 
         Ok(Self {
-            inner: split_kfold(n_samples, k, seed),
+            inner: split_kfold(n_samples, k, seed)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?,
         })
     }
 

--- a/src/python/dataset/splits.rs
+++ b/src/python/dataset/splits.rs
@@ -39,12 +39,12 @@ impl PyHoldoutSplit {
                 "n_samples must be > 0",
             ));
         }
-        if val_ratio < 0.0 || val_ratio >= 1.0 {
+        if !(0.0..1.0).contains(&val_ratio) {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "val_ratio must be in [0.0, 1.0)",
             ));
         }
-        if calib_ratio < 0.0 || calib_ratio >= 1.0 {
+        if !(0.0..1.0).contains(&calib_ratio) {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "calib_ratio must be in [0.0, 1.0)",
             ));
@@ -174,6 +174,7 @@ impl PyKFoldSplit {
     ///
     /// Returns:
     ///     Tuple of (train_indices, val_indices) as numpy arrays
+    #[allow(clippy::type_complexity)] // reason: complex return tuple kept inline
     fn get_fold<'py>(
         &self,
         py: Python<'py>,

--- a/src/python/dataset/types.rs
+++ b/src/python/dataset/types.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 use crate::dataset::{BinnedDataset, FeatureInfo, FeatureType};
 
 /// Python wrapper for FeatureType enum
-#[pyclass(name = "FeatureType", eq)]
+#[pyclass(from_py_object, name = "FeatureType", eq)]
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PyFeatureType {
     inner: FeatureType,
@@ -65,7 +65,7 @@ impl From<PyFeatureType> for FeatureType {
 }
 
 /// Python wrapper for feature metadata
-#[pyclass(name = "FeatureInfo")]
+#[pyclass(from_py_object, name = "FeatureInfo")]
 #[derive(Clone)]
 pub struct PyFeatureInfo {
     inner: FeatureInfo,

--- a/src/python/encoding/filter.rs
+++ b/src/python/encoding/filter.rs
@@ -225,7 +225,7 @@ impl PyCategoryFilter {
 ///
 /// Provides a serializable mapping from categories to indices.
 /// Uses binary search for efficient lookup.
-#[pyclass(name = "CategoryMapping")]
+#[pyclass(from_py_object, name = "CategoryMapping")]
 #[derive(Clone)]
 pub struct PyCategoryMapping {
     inner: CategoryMapping,

--- a/src/python/encoding/target.rs
+++ b/src/python/encoding/target.rs
@@ -145,7 +145,7 @@ impl PyOrderedTargetEncoder {
 ///
 /// Provides a lightweight encoding lookup that can be saved
 /// and used for inference without the full encoder state.
-#[pyclass(name = "EncodingMap")]
+#[pyclass(from_py_object, name = "EncodingMap")]
 #[derive(Clone)]
 pub struct PyEncodingMap {
     inner: EncodingMap,

--- a/src/python/inference/predict.rs
+++ b/src/python/inference/predict.rs
@@ -10,7 +10,7 @@ use crate::inference::{ConformalPredictor, Prediction};
 /// Python wrapper for Prediction
 ///
 /// A prediction result with optional confidence interval.
-#[pyclass(name = "Prediction")]
+#[pyclass(from_py_object, name = "Prediction")]
 #[derive(Clone)]
 pub struct PyPrediction {
     inner: Prediction,
@@ -96,7 +96,7 @@ impl From<Prediction> for PyPrediction {
 ///
 /// Computes prediction intervals with distribution-free coverage guarantees.
 /// Uses split conformal prediction with finite-sample guarantees.
-#[pyclass(name = "ConformalPredictor")]
+#[pyclass(from_py_object, name = "ConformalPredictor")]
 #[derive(Clone)]
 pub struct PyConformalPredictor {
     inner: ConformalPredictor,

--- a/src/python/loss/functions.rs
+++ b/src/python/loss/functions.rs
@@ -18,7 +18,7 @@ use crate::loss::{
 /// - Gradient: ŷ - y
 /// - Hessian: 1.0 (constant)
 /// - Sensitive to outliers
-#[pyclass(name = "MseLoss")]
+#[pyclass(from_py_object, name = "MseLoss")]
 #[derive(Clone)]
 pub struct PyMseLoss {
     inner: MseLoss,
@@ -69,7 +69,7 @@ impl PyMseLoss {
 ///
 /// Smooth approximation to Huber loss that transitions from L2 to L1 behavior.
 /// More robust to outliers than MSE.
-#[pyclass(name = "PseudoHuberLoss")]
+#[pyclass(from_py_object, name = "PseudoHuberLoss")]
 #[derive(Clone)]
 pub struct PyPseudoHuberLoss {
     inner: PseudoHuberLoss,
@@ -142,7 +142,7 @@ impl PyPseudoHuberLoss {
 ///
 /// L(y, ŷ) = -[y * log(p) + (1-y) * log(1-p)]
 /// where p = sigmoid(ŷ)
-#[pyclass(name = "BinaryLogLoss")]
+#[pyclass(from_py_object, name = "BinaryLogLoss")]
 #[derive(Clone)]
 pub struct PyBinaryLogLoss {
     inner: BinaryLogLoss,
@@ -217,7 +217,7 @@ impl PyBinaryLogLoss {
 ///
 /// For multi-class classification with K classes.
 /// Targets should be class indices: 0, 1, 2, ..., K-1.
-#[pyclass(name = "MultiClassLogLoss")]
+#[pyclass(from_py_object, name = "MultiClassLogLoss")]
 #[derive(Clone)]
 pub struct PyMultiClassLogLoss {
     inner: MultiClassLogLoss,

--- a/src/python/tuner/autotuner.rs
+++ b/src/python/tuner/autotuner.rs
@@ -4,7 +4,7 @@
 
 use pyo3::prelude::*;
 
-use crate::booster::GBDTConfig;
+use crate::booster::{GBDTConfig, GBDTModel};
 use crate::tuner::AutoTuner;
 
 use super::callback::{validate_callable, PyProgressCallback};
@@ -206,7 +206,7 @@ impl PyAutoTuner {
         dataset: &PyBinnedDataset,
     ) -> PyResult<(PyGBDTConfig, PySearchHistory)> {
         // Build the AutoTuner
-        let mut tuner = AutoTuner::new(self.base_config.clone());
+        let mut tuner = AutoTuner::<GBDTModel>::new(self.base_config.clone());
 
         if let Some(config) = &self.tuner_config {
             tuner = tuner.with_config(config.clone());
@@ -225,7 +225,7 @@ impl PyAutoTuner {
         }
 
         // Release GIL during tuning for better performance
-        let result = py.allow_threads(|| tuner.tune(&dataset.inner));
+        let result = py.detach(|| tuner.tune(&dataset.inner));
 
         match result {
             Ok((best_config, history)) => {

--- a/src/python/tuner/callback.rs
+++ b/src/python/tuner/callback.rs
@@ -35,7 +35,7 @@ impl PyProgressCallback {
     /// - total: Total number of trials
     pub fn call(&self, trial: &TrialResult, current: usize, total: usize) {
         // Reacquire GIL to call Python
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_trial = PyTrialResult::from(trial.clone());
             let py_trial_obj = Py::new(py, py_trial).unwrap();
 

--- a/src/python/tuner/config.rs
+++ b/src/python/tuner/config.rs
@@ -23,7 +23,7 @@ use super::enums::{
 ///
 /// - Continuous: Float range with optional log scaling
 /// - Discrete: Integer range with step size
-#[pyclass(name = "ParamBounds")]
+#[pyclass(from_py_object, name = "ParamBounds")]
 #[derive(Clone)]
 pub struct PyParamBounds {
     pub(crate) inner: ParamBounds,
@@ -178,7 +178,7 @@ impl From<ParamBounds> for PyParamBounds {
 /// Python wrapper for ParameterSpace
 ///
 /// Collection of parameters to tune during hyperparameter search.
-#[pyclass(name = "ParameterSpace")]
+#[pyclass(from_py_object, name = "ParameterSpace")]
 #[derive(Clone)]
 pub struct PyParameterSpace {
     pub(crate) inner: ParameterSpace,
@@ -228,8 +228,7 @@ impl PyParameterSpace {
     /// Returns:
     ///     Self for method chaining
     fn with_param(&self, name: &str, bounds: &PyParamBounds, center: f32) -> PyResult<Self> {
-        let param = TunableParam::parse(name)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        let param = TunableParam::parse(name).map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(Self {
             inner: self
                 .inner
@@ -254,8 +253,7 @@ impl PyParameterSpace {
                 "min must be less than max",
             ));
         }
-        let param = TunableParam::parse(name)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        let param = TunableParam::parse(name).map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(Self {
             inner: self
                 .inner
@@ -285,8 +283,7 @@ impl PyParameterSpace {
                 "min must be less than max",
             ));
         }
-        let param = TunableParam::parse(name)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        let param = TunableParam::parse(name).map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(Self {
             inner: self.inner.clone().with_param(
                 param,
@@ -312,8 +309,7 @@ impl PyParameterSpace {
                 "min must be less than max",
             ));
         }
-        let param = TunableParam::parse(name)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        let param = TunableParam::parse(name).map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(Self {
             inner: self
                 .inner
@@ -351,8 +347,7 @@ impl PyParameterSpace {
                 "step must be positive",
             ));
         }
-        let param = TunableParam::parse(name)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        let param = TunableParam::parse(name).map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(Self {
             inner: self.inner.clone().with_param(
                 param,
@@ -372,8 +367,7 @@ impl PyParameterSpace {
     /// Returns:
     ///     Self for method chaining
     fn without_param(&self, name: &str) -> PyResult<Self> {
-        let param = TunableParam::parse(name)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        let param = TunableParam::parse(name).map_err(pyo3::exceptions::PyValueError::new_err)?;
         Ok(Self {
             inner: self.inner.clone().without_param(param),
         })
@@ -423,7 +417,7 @@ impl From<ParameterSpace> for PyParameterSpace {
 /// Python wrapper for TunerConfig
 ///
 /// Main configuration for the hyperparameter tuner.
-#[pyclass(name = "TunerConfig")]
+#[pyclass(from_py_object, name = "TunerConfig")]
 #[derive(Clone)]
 pub struct PyTunerConfig {
     pub(crate) inner: TunerConfig,
@@ -611,7 +605,7 @@ impl PyTunerConfig {
     /// Args:
     ///     min_f1: Minimum required F1 score (e.g., 0.5 = 50%)
     fn with_min_f1_score(&self, min_f1: f32) -> PyResult<Self> {
-        if min_f1 < 0.0 || min_f1 > 1.0 {
+        if !(0.0..=1.0).contains(&min_f1) {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "min_f1 must be in [0, 1]",
             ));
@@ -802,7 +796,7 @@ impl PyTunerConfig {
     fn validate(&self) -> PyResult<()> {
         self.inner
             .validate()
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+            .map_err(pyo3::exceptions::PyValueError::new_err)
     }
 
     /// Estimate total number of trials

--- a/src/python/tuner/config.rs
+++ b/src/python/tuner/config.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use pyo3::prelude::*;
 
 use crate::tuner::{
-    ModelFormat, ParamBounds, ParameterSpace, SpacePreset, TunerConfig, TunerPreset,
+    ModelFormat, ParamBounds, ParameterSpace, SpacePreset, TunableParam, TunerConfig, TunerPreset,
 };
 
 use super::enums::{
@@ -162,6 +162,9 @@ impl PyParamBounds {
                     format!("ParamBounds.discrete_step({}, {}, {})", min, max, step)
                 }
             }
+            ParamBounds::Categorical { values } => {
+                format!("ParamBounds.categorical([{}])", values.join(", "))
+            }
         }
     }
 }
@@ -224,13 +227,15 @@ impl PyParameterSpace {
     ///
     /// Returns:
     ///     Self for method chaining
-    fn with_param(&self, name: &str, bounds: &PyParamBounds, center: f32) -> Self {
-        Self {
+    fn with_param(&self, name: &str, bounds: &PyParamBounds, center: f32) -> PyResult<Self> {
+        let param = TunableParam::parse(name)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        Ok(Self {
             inner: self
                 .inner
                 .clone()
-                .with_param(name, bounds.inner.clone(), center),
-        }
+                .with_param(param, bounds.inner.clone(), center),
+        })
     }
 
     /// Add a continuous parameter
@@ -249,11 +254,13 @@ impl PyParameterSpace {
                 "min must be less than max",
             ));
         }
+        let param = TunableParam::parse(name)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
         Ok(Self {
             inner: self
                 .inner
                 .clone()
-                .with_param(name, ParamBounds::continuous(min, max), center),
+                .with_param(param, ParamBounds::continuous(min, max), center),
         })
     }
 
@@ -278,9 +285,11 @@ impl PyParameterSpace {
                 "min must be less than max",
             ));
         }
+        let param = TunableParam::parse(name)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
         Ok(Self {
             inner: self.inner.clone().with_param(
-                name,
+                param,
                 ParamBounds::log_continuous(min, max),
                 center,
             ),
@@ -303,11 +312,13 @@ impl PyParameterSpace {
                 "min must be less than max",
             ));
         }
+        let param = TunableParam::parse(name)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
         Ok(Self {
             inner: self
                 .inner
                 .clone()
-                .with_param(name, ParamBounds::discrete(min, max), center),
+                .with_param(param, ParamBounds::discrete(min, max), center),
         })
     }
 
@@ -340,9 +351,11 @@ impl PyParameterSpace {
                 "step must be positive",
             ));
         }
+        let param = TunableParam::parse(name)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
         Ok(Self {
             inner: self.inner.clone().with_param(
-                name,
+                param,
                 ParamBounds::discrete_step(min, max, step),
                 center,
             ),
@@ -358,10 +371,12 @@ impl PyParameterSpace {
     ///
     /// Returns:
     ///     Self for method chaining
-    fn without_param(&self, name: &str) -> Self {
-        Self {
-            inner: self.inner.clone().without_param(name),
-        }
+    fn without_param(&self, name: &str) -> PyResult<Self> {
+        let param = TunableParam::parse(name)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))?;
+        Ok(Self {
+            inner: self.inner.clone().without_param(param),
+        })
     }
 
     /// Number of parameters in the search space
@@ -377,19 +392,20 @@ impl PyParameterSpace {
 
     /// Get parameter names
     fn param_names(&self) -> Vec<String> {
-        self.inner.param_names()
+        self.inner
+            .param_names()
+            .into_iter()
+            .map(String::from)
+            .collect()
     }
 
     /// Get current centers as a dictionary
     fn centers(&self) -> HashMap<String, f32> {
-        self.inner.centers()
-    }
-
-    /// Validate the parameter space
-    fn validate(&self) -> PyResult<()> {
         self.inner
-            .validate()
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+            .centers()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
     }
 
     fn __repr__(&self) -> String {

--- a/src/python/tuner/enums.rs
+++ b/src/python/tuner/enums.rs
@@ -121,6 +121,16 @@ impl PyOptimizationMetric {
         }
     }
 
+    /// Use Rank IC (higher is better)
+    ///
+    /// Spearman rank correlation between predictions and targets. Regression only.
+    #[staticmethod]
+    fn rank_ic() -> Self {
+        Self {
+            inner: OptimizationMetric::RankIc,
+        }
+    }
+
     /// Check if higher values are better for this metric
     #[getter]
     fn higher_is_better(&self) -> bool {
@@ -138,6 +148,7 @@ impl PyOptimizationMetric {
             OptimizationMetric::ValidationLoss => "OptimizationMetric.val_loss()",
             OptimizationMetric::F1Score => "OptimizationMetric.f1_score()",
             OptimizationMetric::RocAuc => "OptimizationMetric.roc_auc()",
+            OptimizationMetric::RankIc => "OptimizationMetric.rank_ic()",
         }
     }
 }

--- a/src/python/tuner/enums.rs
+++ b/src/python/tuner/enums.rs
@@ -20,7 +20,7 @@ use crate::tuner::{
 ///
 /// - Optimistic: Fast mode, uses pre-encoded data (may have target leakage)
 /// - Realistic: Accurate mode, encodes per split (no target leakage)
-#[pyclass(name = "TuningMode", eq)]
+#[pyclass(from_py_object, name = "TuningMode", eq)]
 #[derive(Clone, PartialEq)]
 pub struct PyTuningMode {
     pub(crate) inner: TuningMode,
@@ -83,7 +83,7 @@ impl From<TuningMode> for PyTuningMode {
 /// - ValidationLoss: Lower is better (default)
 /// - F1Score: Higher is better
 /// - RocAuc: Higher is better (binary classification)
-#[pyclass(name = "OptimizationMetric", eq)]
+#[pyclass(from_py_object, name = "OptimizationMetric", eq)]
 #[derive(Clone, PartialEq)]
 pub struct PyOptimizationMetric {
     pub(crate) inner: OptimizationMetric,
@@ -166,7 +166,7 @@ impl From<OptimizationMetric> for PyOptimizationMetric {
 /// - Regression: Only loss (MSE)
 /// - BinaryClassification: Loss, F1, ROC-AUC
 /// - MultiClassClassification: Loss, F1
-#[pyclass(name = "TaskType", eq)]
+#[pyclass(from_py_object, name = "TaskType", eq)]
 #[derive(Clone, PartialEq)]
 pub struct PyTaskType {
     pub(crate) inner: TaskType,
@@ -237,7 +237,7 @@ impl From<TaskType> for PyTaskType {
 ///
 /// - Rkyv: Zero-copy deserialization, fastest loading
 /// - Bincode: Compact binary, serde-based
-#[pyclass(name = "ModelFormat", eq)]
+#[pyclass(from_py_object, name = "ModelFormat", eq)]
 #[derive(Clone, PartialEq)]
 pub struct PyModelFormat {
     pub(crate) inner: ModelFormat,
@@ -300,7 +300,7 @@ impl From<ModelFormat> for PyModelFormat {
 /// - Cartesian: Full grid (points_per_dim^n candidates)
 /// - LatinHypercube: Space-filling design
 /// - Random: Pure random sampling
-#[pyclass(name = "GridStrategy", eq)]
+#[pyclass(from_py_object, name = "GridStrategy", eq)]
 #[derive(Clone, PartialEq)]
 pub struct PyGridStrategy {
     pub(crate) inner: GridStrategy,
@@ -396,7 +396,7 @@ impl From<GridStrategy> for PyGridStrategy {
 ///
 /// - Holdout: Train/validation split with optional k-fold CV
 /// - Conformal: Prediction interval-based evaluation
-#[pyclass(name = "EvalStrategy", eq)]
+#[pyclass(from_py_object, name = "EvalStrategy", eq)]
 #[derive(Clone, PartialEq)]
 pub struct PyEvalStrategy {
     pub(crate) inner: EvalStrategy,

--- a/src/python/tuner/results.rs
+++ b/src/python/tuner/results.rs
@@ -15,7 +15,7 @@ use super::enums::PyOptimizationMetric;
 /// Python wrapper for TrialResult
 ///
 /// Contains the results of a single hyperparameter trial.
-#[pyclass(name = "TrialResult")]
+#[pyclass(from_py_object, name = "TrialResult")]
 #[derive(Clone)]
 pub struct PyTrialResult {
     inner: TrialResult,
@@ -116,7 +116,7 @@ impl From<&TrialResult> for PyTrialResult {
 /// Python wrapper for SearchHistory
 ///
 /// Tracks all trial results and maintains the best trial.
-#[pyclass(name = "SearchHistory")]
+#[pyclass(from_py_object, name = "SearchHistory")]
 #[derive(Clone)]
 pub struct PySearchHistory {
     pub(crate) inner: SearchHistory,

--- a/src/python/tuner/results.rs
+++ b/src/python/tuner/results.rs
@@ -229,6 +229,7 @@ fn get_metric_value(trial: &TrialResult, metric: OptimizationMetric) -> f32 {
         OptimizationMetric::ValidationLoss => trial.val_loss,
         OptimizationMetric::F1Score => trial.f1_score.unwrap_or(0.0),
         OptimizationMetric::RocAuc => trial.roc_auc.unwrap_or(0.0) as f32,
+        OptimizationMetric::RankIc => trial.rank_ic.unwrap_or(0.0) as f32,
     }
 }
 

--- a/src/serialize/bincode_io.rs
+++ b/src/serialize/bincode_io.rs
@@ -11,9 +11,10 @@ use std::path::Path;
 /// Save a model to a bincode file
 pub fn save_model_bincode(model: &GBDTModel, path: impl AsRef<Path>) -> Result<()> {
     let file = File::create(path)?;
-    let writer = BufWriter::new(file);
+    let mut writer = BufWriter::new(file);
+    let config = bincode::config::standard();
 
-    bincode::serialize_into(writer, model).map_err(|e| {
+    bincode::serde::encode_into_std_write(model, &mut writer, config).map_err(|e| {
         TreeBoostError::Serialization(format!("Failed to serialize bincode: {}", e))
     })?;
 
@@ -23,9 +24,10 @@ pub fn save_model_bincode(model: &GBDTModel, path: impl AsRef<Path>) -> Result<(
 /// Load a model from a bincode file
 pub fn load_model_bincode(path: impl AsRef<Path>) -> Result<GBDTModel> {
     let file = File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
+    let config = bincode::config::standard();
 
-    let model: GBDTModel = bincode::deserialize_from(reader).map_err(|e| {
+    let model: GBDTModel = bincode::serde::decode_from_std_read(&mut reader, config).map_err(|e| {
         TreeBoostError::Serialization(format!("Failed to deserialize bincode: {}", e))
     })?;
 

--- a/src/serialize/bincode_io.rs
+++ b/src/serialize/bincode_io.rs
@@ -27,9 +27,10 @@ pub fn load_model_bincode(path: impl AsRef<Path>) -> Result<GBDTModel> {
     let mut reader = BufReader::new(file);
     let config = bincode::config::standard();
 
-    let model: GBDTModel = bincode::serde::decode_from_std_read(&mut reader, config).map_err(|e| {
-        TreeBoostError::Serialization(format!("Failed to deserialize bincode: {}", e))
-    })?;
+    let model: GBDTModel =
+        bincode::serde::decode_from_std_read(&mut reader, config).map_err(|e| {
+            TreeBoostError::Serialization(format!("Failed to deserialize bincode: {}", e))
+        })?;
 
     Ok(model)
 }

--- a/src/serialize/trb.rs
+++ b/src/serialize/trb.rs
@@ -1163,7 +1163,7 @@ mod tests {
         file.read_exact(&mut total_size_bytes).unwrap();
         let mut header_size_bytes = [0u8; 8];
         file.read_exact(&mut header_size_bytes).unwrap();
-        let header_size = u64::from_le_bytes(header_size_bytes) as u64;
+        let header_size = u64::from_le_bytes(header_size_bytes);
 
         // Blob starts at: base_end + 8 (total_size) + 8 (header_size) + header_size
         let blob_start = base_end + 8 + 8 + header_size;

--- a/src/serialize/trb.rs
+++ b/src/serialize/trb.rs
@@ -49,7 +49,6 @@
 //! ```
 
 use crate::{Result, TreeBoostError};
-use fs4::fs_std::FileExt;
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -148,7 +147,7 @@ impl TrbWriter {
             .open(path.as_ref())?;
 
         // Acquire exclusive lock
-        file.try_lock_exclusive().map_err(|e| {
+        file.try_lock().map_err(|e| {
             TreeBoostError::Serialization(format!("Failed to acquire file lock: {}", e))
         })?;
 
@@ -481,7 +480,7 @@ pub fn open_for_append(path: impl AsRef<Path>) -> Result<TrbWriter> {
         .open(path.as_ref())?;
 
     // Acquire exclusive lock
-    file.try_lock_exclusive().map_err(|e| {
+    file.try_lock().map_err(|e| {
         TreeBoostError::Serialization(format!("Failed to acquire file lock: {}", e))
     })?;
 

--- a/src/tree/grow.rs
+++ b/src/tree/grow.rs
@@ -905,10 +905,7 @@ impl TreeGrower {
                 };
 
             // Phase 3: Process results - compute larger children, find splits, push to heap
-            for (state, smaller_hists) in batch_states
-                .into_iter()
-                .zip(all_smaller_histograms.into_iter())
-            {
+            for (state, smaller_hists) in batch_states.into_iter().zip(all_smaller_histograms) {
                 let smaller_histograms = NodeHistograms::from_vec(smaller_hists);
 
                 // Extract parent histograms (must be Standard variant in this path)
@@ -1651,10 +1648,7 @@ impl TreeGrower {
                 };
 
             // Phase 3: Process results
-            for (state, smaller_hists) in batch_states
-                .into_iter()
-                .zip(all_smaller_histograms.into_iter())
-            {
+            for (state, smaller_hists) in batch_states.into_iter().zip(all_smaller_histograms) {
                 let smaller_histograms = NodeHistograms::from_vec(smaller_hists);
 
                 // Extract parent histograms (must be Standard variant in grow_fused path)

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -193,7 +193,7 @@ mod tests {
         assert!((v - 5.5).abs() < 1e-10);
         assert_eq!(l, 1);
         assert_eq!(r, 2);
-        assert_eq!(d, true);
+        assert!(d);
         assert!((g - 10.5).abs() < 1e-6);
     }
 

--- a/src/tree/split.rs
+++ b/src/tree/split.rs
@@ -804,11 +804,11 @@ impl SplitFinder {
 
             // Check that eras 0 and 1 exist in per_era_totals
             let has_era_0 = per_era_totals
-                .get(0)
-                .map_or(false, |(_, _, count)| *count > 0);
+                .first()
+                .is_some_and(|(_, _, count)| *count > 0);
             let has_era_1 = per_era_totals
                 .get(1)
-                .map_or(false, |(_, _, count)| *count > 0);
+                .is_some_and(|(_, _, count)| *count > 0);
 
             if !has_era_0 || !has_era_1 {
                 eprintln!(

--- a/src/tuner/autotuner/execution.rs
+++ b/src/tuner/autotuner/execution.rs
@@ -100,7 +100,7 @@ fn evaluate_single<M: TunableModel>(
     if !full_params.contains_key("learning_rate") {
         full_params.insert(
             "learning_rate".into(),
-            M::get_learning_rate(&tuner.base_config()),
+            M::get_learning_rate(tuner.base_config()),
         );
     }
 
@@ -210,6 +210,8 @@ pub(super) fn evaluate_candidates<M: TunableModel>(
 /// Evaluate candidates for realistic mode (encoding per split)
 ///
 /// For realistic mode, we cannot parallelize because encoding is stateful.
+// reason: kernel/training entry point with many parameters
+#[allow(clippy::too_many_arguments)]
 pub(super) fn evaluate_candidates_internal<M: TunableModel>(
     tuner: &crate::tuner::AutoTuner<M>,
     raw_data: &DataFrame,

--- a/src/tuner/autotuner/execution.rs
+++ b/src/tuner/autotuner/execution.rs
@@ -274,7 +274,7 @@ pub(super) fn is_gpu_backend<M: TunableModel>(base_config: &M::Config) -> bool {
 /// to a random position within its bounds.
 pub(super) fn randomize_centers<M: TunableModel>(tuner: &mut crate::tuner::AutoTuner<M>) {
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
 
     // Use a seed derived from current iteration count for reproducibility
     let seed = tuner.seed().wrapping_add(tuner.history_len() as u64);

--- a/src/tuner/autotuner/grid.rs
+++ b/src/tuner/autotuner/grid.rs
@@ -202,7 +202,7 @@ pub(crate) fn generate_lhs_grid(
 ) -> Vec<HashMap<String, f32>> {
     use rand::rngs::StdRng;
     use rand::seq::SliceRandom;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
 
     if n_samples == 0 {
         return Vec::new();
@@ -275,7 +275,7 @@ pub(crate) fn generate_random_grid(
     seed: u64,
 ) -> Vec<HashMap<String, f32>> {
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
 
     if n_samples == 0 {
         return Vec::new();

--- a/src/tuner/autotuner/tests.rs
+++ b/src/tuner/autotuner/tests.rs
@@ -127,7 +127,7 @@ fn test_autotuner_generate_param_values() {
     let param = ParamDef::new(TunableParam::MaxDepth, ParamBounds::discrete(2, 10), 6.0);
     let values = tuner.generate_param_values(&param, 0.5, 3);
     assert!(!values.is_empty());
-    assert!(values.iter().all(|&v| v >= 2.0 && v <= 10.0));
+    assert!(values.iter().all(|&v| (2.0..=10.0).contains(&v)));
 }
 
 #[test]
@@ -300,14 +300,14 @@ fn test_lhs_bounds_respected() {
     for candidate in &grid {
         let lr = candidate["learning_rate"];
         assert!(
-            lr >= 0.01 && lr <= 0.5,
+            (0.01..=0.5).contains(&lr),
             "learning_rate {} out of bounds [0.01, 0.5]",
             lr
         );
 
         let depth = candidate["max_depth"];
         assert!(
-            depth >= 2.0 && depth <= 12.0,
+            (2.0..=12.0).contains(&depth),
             "max_depth {} out of bounds [2, 12]",
             depth
         );
@@ -431,14 +431,14 @@ fn test_random_bounds_respected() {
     for candidate in &grid {
         let ss = candidate["subsample"];
         assert!(
-            ss >= 0.5 && ss <= 1.0,
+            (0.5..=1.0).contains(&ss),
             "subsample {} out of bounds [0.5, 1.0]",
             ss
         );
 
         let ew = candidate["entropy_weight"];
         assert!(
-            ew >= 0.0 && ew <= 0.5,
+            (0.0..=0.5).contains(&ew),
             "entropy_weight {} out of bounds [0.0, 0.5]",
             ew
         );
@@ -555,9 +555,11 @@ fn test_spread_affects_range() {
 #[test]
 fn test_is_gpu_backend() {
     // Test GPU backends are detected
-    let mut config = GBDTConfig::default();
+    let mut config = GBDTConfig {
+        backend_type: BackendType::Auto,
+        ..Default::default()
+    };
 
-    config.backend_type = BackendType::Auto;
     let tuner = AutoTuner::<GBDTModel>::new(config.clone());
     assert!(
         tuner.is_gpu_backend(),
@@ -589,8 +591,10 @@ fn test_is_gpu_backend() {
 #[test]
 fn test_parallel_config_respected() {
     // Test that parallel_trials setting is respected
-    let mut config = GBDTConfig::default();
-    config.backend_type = BackendType::Scalar; // CPU backend
+    let config = GBDTConfig {
+        backend_type: BackendType::Scalar, // CPU backend
+        ..Default::default()
+    };
 
     let tuner_config = TunerConfig::new().with_parallel(true).with_n_parallel(4);
 

--- a/src/tuner/autotuner/types.rs
+++ b/src/tuner/autotuner/types.rs
@@ -30,7 +30,7 @@ pub(super) const BINARY_CLASSIFICATION_THRESHOLD: f32 = 0.5;
 /// 1. Panics are exceptional - normal code paths always clean up
 /// 2. After a panic, the AutoTuner is in an undefined state anyway
 /// 3. The pointers are only accessed through methods that check custom_validation first
-pub(super) struct SendPtr<T>(*const T);
+pub(crate) struct SendPtr<T>(*const T);
 
 unsafe impl<T> Send for SendPtr<T> {}
 unsafe impl<T> Sync for SendPtr<T> {}

--- a/src/tuner/ltt.rs
+++ b/src/tuner/ltt.rs
@@ -194,19 +194,10 @@ impl TreeHyperparams {
 }
 
 /// Combined LTT configuration
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct LttConfig {
     pub linear: LinearHyperparams,
     pub tree: TreeHyperparams,
-}
-
-impl Default for LttConfig {
-    fn default() -> Self {
-        Self {
-            linear: LinearHyperparams::default(),
-            tree: TreeHyperparams::default(),
-        }
-    }
 }
 
 /// Result of LTT tuning
@@ -1384,8 +1375,10 @@ mod tests {
 
     #[test]
     fn test_config_validation_empty_grids() {
-        let mut config = LttTunerConfig::default();
-        config.lambda_values = vec![];
+        let config = LttTunerConfig {
+            lambda_values: vec![],
+            ..Default::default()
+        };
 
         let result = config.validate();
         assert!(result.is_err());
@@ -1394,8 +1387,10 @@ mod tests {
 
     #[test]
     fn test_config_validation_bad_val_ratio() {
-        let mut config = LttTunerConfig::default();
-        config.val_ratio = 1.5; // Invalid
+        let config = LttTunerConfig {
+            val_ratio: 1.5, // Invalid
+            ..Default::default()
+        };
 
         let result = config.validate();
         assert!(result.is_err());
@@ -1545,15 +1540,24 @@ mod tests {
 
     #[test]
     fn test_constants_are_reasonable() {
-        // Verify our named constants have sensible values
-        assert!(ltt_defaults::STRONG_LINEAR_R2 > ltt_defaults::WEAK_LINEAR_R2);
-        assert!(ltt_defaults::HIGH_SHRINKAGE_MIN > 0.0 && ltt_defaults::HIGH_SHRINKAGE_MIN < 1.0);
-        assert!(ltt_defaults::LOW_SHRINKAGE_MAX > 0.0 && ltt_defaults::LOW_SHRINKAGE_MAX < 1.0);
-        assert!(
-            ltt_defaults::DEFAULT_LTT_SHRINKAGE > 0.0 && ltt_defaults::DEFAULT_LTT_SHRINKAGE <= 1.0
-        );
-        assert!(ltt_defaults::HIGH_VARIANCE_THRESHOLD > 0.0);
-        assert!(ltt_defaults::MAX_DEPTH_THRESHOLD > 0);
-        assert!(ltt_defaults::MIN_LR_THRESHOLD > 0.0);
+        // Verify our named constants have sensible values.
+        // Bind to runtime locals so these are genuine runtime checks of the
+        // configured constant values, not compile-time constant assertions.
+        let strong_r2 = std::hint::black_box(ltt_defaults::STRONG_LINEAR_R2);
+        let weak_r2 = std::hint::black_box(ltt_defaults::WEAK_LINEAR_R2);
+        let high_shrinkage_min = std::hint::black_box(ltt_defaults::HIGH_SHRINKAGE_MIN);
+        let low_shrinkage_max = std::hint::black_box(ltt_defaults::LOW_SHRINKAGE_MAX);
+        let default_shrinkage = std::hint::black_box(ltt_defaults::DEFAULT_LTT_SHRINKAGE);
+        let high_variance_threshold = std::hint::black_box(ltt_defaults::HIGH_VARIANCE_THRESHOLD);
+        let max_depth_threshold = std::hint::black_box(ltt_defaults::MAX_DEPTH_THRESHOLD);
+        let min_lr_threshold = std::hint::black_box(ltt_defaults::MIN_LR_THRESHOLD);
+
+        assert!(strong_r2 > weak_r2);
+        assert!(high_shrinkage_min > 0.0 && high_shrinkage_min < 1.0);
+        assert!(low_shrinkage_max > 0.0 && low_shrinkage_max < 1.0);
+        assert!(default_shrinkage > 0.0 && default_shrinkage <= 1.0);
+        assert!(high_variance_threshold > 0.0);
+        assert!(max_depth_threshold > 0);
+        assert!(min_lr_threshold > 0.0);
     }
 }

--- a/src/tuner/metrics.rs
+++ b/src/tuner/metrics.rs
@@ -270,13 +270,11 @@ pub fn compute_rank_ic(predictions: &[f32], targets: &[f32], era_indices: Option
         }
     }
 
-    let avg_ic = if valid_eras == 0 {
+    if valid_eras == 0 {
         0.0
     } else {
         ic_sum / valid_eras as f64
-    };
-
-    avg_ic
+    }
 }
 
 /// Compute Spearman rank correlation between two vectors

--- a/src/tuner/traits.rs
+++ b/src/tuner/traits.rs
@@ -302,10 +302,10 @@ mod tests {
 
     #[test]
     fn test_param_value_numeric() {
-        let v = ParamValue::Numeric(3.14);
+        let v = ParamValue::Numeric(2.5);
         assert!(v.is_numeric());
         assert!(!v.is_categorical());
-        assert!((v.as_numeric() - 3.14).abs() < 1e-6);
+        assert!((v.as_numeric() - 2.5).abs() < 1e-6);
         assert!(v.as_categorical().is_none());
     }
 
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_param_value_from() {
-        let v1: ParamValue = 3.14f32.into();
+        let v1: ParamValue = 2.5f32.into();
         assert!(v1.is_numeric());
 
         let v2: ParamValue = "LinearThenTree".into();

--- a/tests/automl_ltt.rs
+++ b/tests/automl_ltt.rs
@@ -12,7 +12,7 @@ fn test_shrinkage_factor_applied() -> Result<(), Box<dyn std::error::Error>> {
     let x: Vec<f64> = (0..50).map(|i| i as f64 * 0.1).collect();
     let y: Vec<f64> = x.iter().map(|v| 2.0 * v + 5.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(50, vec![
         Series::new("x".into(), x).into(),
         Series::new("target".into(), y.clone()).into(),
     ])
@@ -70,7 +70,7 @@ fn test_ltt_pure_linear_data() -> Result<(), Box<dyn std::error::Error>> {
     let x_values: Vec<f64> = (0..100).map(|i| i as f64).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(100, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("target".into(), y_values.clone()).into(),
     ])
@@ -150,7 +150,7 @@ fn test_ltt_linear_plus_residual() -> Result<(), Box<dyn std::error::Error>> {
     let x_values: Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + x.sin()).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(100, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("target".into(), y_values.clone()).into(),
     ])
@@ -237,7 +237,7 @@ fn test_ltt_with_categoricals() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(100, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("category".into(), cat_values).into(),
         Series::new("target".into(), y_values.clone()).into(),
@@ -300,7 +300,7 @@ fn test_ltt_with_id_like_columns() -> Result<(), Box<dyn std::error::Error>> {
     let id_values: Vec<String> = (0..100).map(|i| format!("ID_{:04}", i)).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(100, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("id".into(), id_values).into(),
         Series::new("target".into(), y_values.clone()).into(),
@@ -359,7 +359,7 @@ fn test_ltt_with_user_exclusions() -> Result<(), Box<dyn std::error::Error>> {
     let corr_values: Vec<f64> = x_values.iter().map(|x| x * 3.0).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(100, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("correlated".into(), corr_values).into(),
         Series::new("target".into(), y_values.clone()).into(),
@@ -407,7 +407,7 @@ fn test_ltt_feature_extractor_storage() -> Result<(), Box<dyn std::error::Error>
         .collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(50, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("category".into(), cat_values).into(),
         Series::new("target".into(), y_values.clone()).into(),
@@ -479,7 +479,7 @@ fn test_ltt_with_pipeline_encoded_categoricals() -> Result<(), Box<dyn std::erro
         })
         .collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(200, vec![
         Series::new("x".into(), x_values.clone()).into(),
         Series::new("cat1".into(), cat1_values).into(),
         Series::new("cat2".into(), cat2_values).into(),
@@ -494,7 +494,7 @@ fn test_ltt_with_pipeline_encoded_categoricals() -> Result<(), Box<dyn std::erro
         df.width()
     );
     println!("Original dtypes:");
-    for col in df.get_columns() {
+    for col in df.columns() {
         println!("  {} : {:?}", col.name(), col.dtype());
     }
 
@@ -575,7 +575,7 @@ fn test_early_failure_when_all_features_dropped() {
     let id_values: Vec<i64> = (0..100).collect(); // Sequential integers [0, 1, 2, ..., 99]
     let target_values: Vec<f64> = (0..100).map(|i| i as f64 * 2.0).collect();
 
-    let df = DataFrame::new(vec![
+    let df = DataFrame::new(100, vec![
         Series::new("id".into(), id_values).into(), // Will be dropped (ID-like name + pattern)
         Series::new("target".into(), target_values).into(),
     ])

--- a/tests/automl_ltt.rs
+++ b/tests/automl_ltt.rs
@@ -567,8 +567,6 @@ fn test_ltt_with_pipeline_encoded_categoricals() -> Result<(), Box<dyn std::erro
     Ok(())
 }
 // Test to verify early validation when all features are dropped
-use polars::prelude::*;
-
 #[test]
 fn test_early_failure_when_all_features_dropped() {
     // Create data where the only feature will be dropped as ID-like

--- a/tests/automl_ltt.rs
+++ b/tests/automl_ltt.rs
@@ -12,10 +12,13 @@ fn test_shrinkage_factor_applied() -> Result<(), Box<dyn std::error::Error>> {
     let x: Vec<f64> = (0..50).map(|i| i as f64 * 0.1).collect();
     let y: Vec<f64> = x.iter().map(|v| 2.0 * v + 5.0).collect();
 
-    let df = DataFrame::new(50, vec![
-        Series::new("x".into(), x).into(),
-        Series::new("target".into(), y.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        50,
+        vec![
+            Series::new("x".into(), x).into(),
+            Series::new("target".into(), y.clone()).into(),
+        ],
+    )
     .unwrap();
 
     // Test different shrinkage values are stored and affect predictions
@@ -70,10 +73,13 @@ fn test_ltt_pure_linear_data() -> Result<(), Box<dyn std::error::Error>> {
     let x_values: Vec<f64> = (0..100).map(|i| i as f64).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(100, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        100,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     println!("\n=== Test: Pure Linear Data (y = 2x + 3) ===");
@@ -150,10 +156,13 @@ fn test_ltt_linear_plus_residual() -> Result<(), Box<dyn std::error::Error>> {
     let x_values: Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + x.sin()).collect();
 
-    let df = DataFrame::new(100, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        100,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     println!("\n=== Test: Linear + Nonlinear (y = 2x + sin(x)) ===");
@@ -237,11 +246,14 @@ fn test_ltt_with_categoricals() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(100, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("category".into(), cat_values).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        100,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("category".into(), cat_values).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     println!("\n=== Test: LTT with Categoricals ===");
@@ -300,11 +312,14 @@ fn test_ltt_with_id_like_columns() -> Result<(), Box<dyn std::error::Error>> {
     let id_values: Vec<String> = (0..100).map(|i| format!("ID_{:04}", i)).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(100, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("id".into(), id_values).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        100,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("id".into(), id_values).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     // Use same good config as first test
@@ -359,11 +374,14 @@ fn test_ltt_with_user_exclusions() -> Result<(), Box<dyn std::error::Error>> {
     let corr_values: Vec<f64> = x_values.iter().map(|x| x * 3.0).collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(100, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("correlated".into(), corr_values).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        100,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("correlated".into(), corr_values).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     // Configure linear features to exclude "correlated"
@@ -407,11 +425,14 @@ fn test_ltt_feature_extractor_storage() -> Result<(), Box<dyn std::error::Error>
         .collect();
     let y_values: Vec<f64> = x_values.iter().map(|x| x * 2.0 + 3.0).collect();
 
-    let df = DataFrame::new(50, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("category".into(), cat_values).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        50,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("category".into(), cat_values).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     let config = AutoConfig::new()
@@ -479,12 +500,15 @@ fn test_ltt_with_pipeline_encoded_categoricals() -> Result<(), Box<dyn std::erro
         })
         .collect();
 
-    let df = DataFrame::new(200, vec![
-        Series::new("x".into(), x_values.clone()).into(),
-        Series::new("cat1".into(), cat1_values).into(),
-        Series::new("cat2".into(), cat2_values).into(),
-        Series::new("target".into(), y_values.clone()).into(),
-    ])
+    let df = DataFrame::new(
+        200,
+        vec![
+            Series::new("x".into(), x_values.clone()).into(),
+            Series::new("cat1".into(), cat1_values).into(),
+            Series::new("cat2".into(), cat2_values).into(),
+            Series::new("target".into(), y_values.clone()).into(),
+        ],
+    )
     .unwrap();
 
     println!("\n=== Testing LTT with Pipeline-Encoded Categoricals ===");
@@ -573,10 +597,13 @@ fn test_early_failure_when_all_features_dropped() {
     let id_values: Vec<i64> = (0..100).collect(); // Sequential integers [0, 1, 2, ..., 99]
     let target_values: Vec<f64> = (0..100).map(|i| i as f64 * 2.0).collect();
 
-    let df = DataFrame::new(100, vec![
-        Series::new("id".into(), id_values).into(), // Will be dropped (ID-like name + pattern)
-        Series::new("target".into(), target_values).into(),
-    ])
+    let df = DataFrame::new(
+        100,
+        vec![
+            Series::new("id".into(), id_values).into(), // Will be dropped (ID-like name + pattern)
+            Series::new("target".into(), target_values).into(),
+        ],
+    )
     .unwrap();
 
     let config =

--- a/tests/automl_multilabel.rs
+++ b/tests/automl_multilabel.rs
@@ -37,7 +37,7 @@ fn create_multilabel_dataframe(n_rows: usize, n_labels: usize, seed: u64) -> Dat
         columns.push(Column::new(format!("label_{}", k).into(), label));
     }
 
-    DataFrame::new(columns).unwrap()
+    DataFrame::new(n_rows, columns).unwrap()
 }
 
 // =============================================================================
@@ -426,5 +426,5 @@ fn create_imbalanced_multilabel_dataframe(n_rows: usize, n_labels: usize, seed: 
         columns.push(Column::new(format!("label_{}", k).into(), label));
     }
 
-    DataFrame::new(columns).unwrap()
+    DataFrame::new(n_rows, columns).unwrap()
 }

--- a/tests/automl_multilabel.rs
+++ b/tests/automl_multilabel.rs
@@ -113,6 +113,9 @@ fn test_automl_multilabel_correctness() {
         .expect("Prediction should succeed");
 
     // Compute accuracy per label
+    // `k` indexes the label dimension of row-major `proba[row][k]` and builds the
+    // column name, so there is no single slice to drive the loop via an iterator.
+    #[allow(clippy::needless_range_loop)]
     for k in 0..n_labels {
         let col_name = format!("label_{}", k);
         let targets: Vec<f64> = df
@@ -193,7 +196,7 @@ fn test_threshold_tuning() {
     // Thresholds should be in valid range
     for &threshold in &tune_result.thresholds {
         assert!(
-            threshold >= 0.01 && threshold <= 0.99,
+            (0.01..=0.99).contains(&threshold),
             "Threshold {} should be in [0.01, 0.99]",
             threshold
         );
@@ -253,7 +256,7 @@ fn test_threshold_tuning_improves_f1() {
     // Tuned thresholds should give reasonable F1 scores
     for &f1 in &tune_result.f1_scores {
         assert!(
-            f1 >= 0.0 && f1 <= 1.0,
+            (0.0..=1.0).contains(&f1),
             "F1 score {} should be in [0, 1]",
             f1
         );
@@ -289,7 +292,7 @@ fn test_multilabel_end_to_end_workflow() {
     // Verify tuning produced valid results
     assert_eq!(tune_result.thresholds.len(), n_labels);
     for &t in &tune_result.thresholds {
-        assert!(t >= 0.01 && t <= 0.99, "Threshold {} out of range", t);
+        assert!((0.01..=0.99).contains(&t), "Threshold {} out of range", t);
     }
 
     // 4. Make predictions with tuned thresholds
@@ -310,7 +313,7 @@ fn test_multilabel_end_to_end_workflow() {
         // Probabilities should be in [0, 1]
         for &prob in p {
             assert!(
-                prob >= 0.0 && prob <= 1.0,
+                (0.0..=1.0).contains(&prob),
                 "Probability {} out of range",
                 prob
             );

--- a/tests/booster.rs
+++ b/tests/booster.rs
@@ -553,7 +553,7 @@ fn test_multilabel_predictions_shape() {
     let proba = model.predict_proba_multilabel(&dataset);
     for row in &proba {
         for &p in row {
-            assert!(p >= 0.0 && p <= 1.0, "Probability out of range: {}", p);
+            assert!((0.0..=1.0).contains(&p), "Probability out of range: {}", p);
         }
     }
 
@@ -604,7 +604,7 @@ fn test_predict_multilabel() {
         assert_eq!(row_proba.len(), num_outputs);
         for &p in row_proba {
             assert!(
-                p >= 0.0 && p <= 1.0,
+                (0.0..=1.0).contains(&p),
                 "Probability must be in [0, 1], got {}",
                 p
             );
@@ -639,7 +639,7 @@ fn test_predict_labels_with_threshold() {
     for row in &proba {
         for &p in row {
             assert!(
-                p >= 0.0 && p <= 1.0,
+                (0.0..=1.0).contains(&p),
                 "Probability should be in [0, 1], got {}",
                 p
             );
@@ -953,7 +953,7 @@ fn test_vector_tree_predictions_quality() {
     // 1. All probabilities in valid range [0, 1]
     for row in &proba {
         for &p in row {
-            assert!(p >= 0.0 && p <= 1.0, "Invalid probability: {}", p);
+            assert!((0.0..=1.0).contains(&p), "Invalid probability: {}", p);
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,7 @@
 //! Shared test utilities for TreeBoost integration tests
+// reason: each integration test file is its own crate; some helpers are
+// only used by a subset of them, so they appear unused per-crate.
+#![allow(dead_code)]
 
 use polars::prelude::*;
 use treeboost::dataset::{BinnedDataset, FeatureInfo, FeatureType};
@@ -219,7 +222,7 @@ pub fn generate_multiclass_data(
     imbalance: Vec<f64>,
     seed: u64,
 ) -> Result<DataFrame> {
-    if num_classes < 2 || num_classes > 10 {
+    if !(2..=10).contains(&num_classes) {
         return Err(treeboost::TreeBoostError::Config(
             "num_classes must be between 2 and 10".to_string(),
         ));
@@ -323,7 +326,7 @@ pub fn generate_multilabel_data(
     correlations: Vec<(usize, usize)>,
     seed: u64,
 ) -> Result<DataFrame> {
-    if num_labels < 2 || num_labels > 10 {
+    if !(2..=10).contains(&num_labels) {
         return Err(treeboost::TreeBoostError::Config(
             "num_labels must be between 2 and 10".to_string(),
         ));
@@ -377,7 +380,7 @@ pub fn generate_multilabel_data(
         let mut labels = vec![0; num_labels];
 
         // Base probabilities from features
-        for label_id in 0..num_labels {
+        for (label_id, label) in labels.iter_mut().enumerate() {
             let signal = match label_id {
                 0 => f1 + f2 * 0.5,              // Label 0 depends on f1, f2
                 1 => f2 * 0.8 + f3 * 0.3,        // Label 1 depends on f2, f3
@@ -387,7 +390,7 @@ pub fn generate_multilabel_data(
 
             // Sigmoid to get probability
             let prob = 1.0 / (1.0 + (-signal).exp());
-            labels[label_id] = if next_rand() < prob { 1 } else { 0 };
+            *label = if next_rand() < prob { 1 } else { 0 };
         }
 
         // Apply correlations: if label i is 1 and (i, j) is correlated, increase prob of j

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -418,7 +418,7 @@ pub fn generate_multilabel_data(
     // Add label columns
     for (label_id, label_vec) in label_vecs.into_iter().enumerate() {
         let label_series = Series::new(format!("label_{}", label_id).into(), label_vec);
-        let _ = df_builder.with_column(label_series).map_err(|e| {
+        let _ = df_builder.with_column(label_series.into()).map_err(|e| {
             treeboost::TreeBoostError::Config(format!("Failed to add label column: {}", e))
         })?;
     }

--- a/tests/conformal_prediction.rs
+++ b/tests/conformal_prediction.rs
@@ -42,7 +42,7 @@ fn generate_complex_data(
 
     for i in 0..n {
         let v1 = (i as f64 / n as f64) * 10.0 - 5.0; // [-5, 5]
-        let v2 = (i as f64 / n as f64) * 6.28; // [0, 2π]
+        let v2 = (i as f64 / n as f64) * std::f64::consts::TAU; // [0, 2π]
         let v3 = next_rand() * 2.0; // Normal(0, 2)
         let v4 = next_rand() * 2.0; // Normal(0, 2)
         let v5 = next_rand(); // Normal(0, 1)
@@ -138,8 +138,7 @@ fn dataframe_to_binned_with_stats(
     // Create feature info
     let feature_info: Vec<treeboost::dataset::FeatureInfo> = feature_cols
         .iter()
-        .enumerate()
-        .map(|(_i, &name)| treeboost::dataset::FeatureInfo {
+        .map(|&name| treeboost::dataset::FeatureInfo {
             name: name.to_string(),
             feature_type: treeboost::dataset::FeatureType::Numeric,
             num_bins: 255,
@@ -238,7 +237,7 @@ fn test_conformal_coverage_90_percent() -> Result<(), Box<dyn std::error::Error>
 
     // Assertions
     assert!(
-        coverage >= 0.85 && coverage <= 0.95,
+        (0.85..=0.95).contains(&coverage),
         "Coverage should be 85-95% for 90% intervals, got {:.2}%",
         coverage * 100.0
     );
@@ -439,7 +438,7 @@ fn test_conformal_with_noisy_data() -> Result<(), Box<dyn std::error::Error>> {
 
     // Assertions
     assert!(
-        coverage >= 0.85 && coverage <= 0.95,
+        (0.85..=0.95).contains(&coverage),
         "Coverage should be 85-95% even with noise, got {:.2}%",
         coverage * 100.0
     );

--- a/tests/era_rankic.rs
+++ b/tests/era_rankic.rs
@@ -179,7 +179,7 @@ fn test_rank_ic_with_eras_is_correct() {
     // For synthetic data with clear patterns, cross-sectional IC can also be very high
     // The key difference is the METHODOLOGY (per-era vs global), not necessarily the value
     assert!(
-        ic_correct >= -0.5 && ic_correct <= 1.0,
+        (-0.5..=1.0).contains(&ic_correct),
         "IC with eras should be reasonable: got {:.4}",
         ic_correct
     );
@@ -275,12 +275,12 @@ fn test_comparison_with_vs_without_eras() {
     // - WITHOUT eras: ranks ALL 12 rows together (time leakage)
     // - WITH eras: ranks 3 rows within each of 4 dates (correct)
     assert!(
-        ic_without >= -0.5 && ic_without <= 1.0,
+        (-0.5..=1.0).contains(&ic_without),
         "IC without eras should be reasonable: got {:.4}",
         ic_without
     );
     assert!(
-        ic_with >= -0.5 && ic_with <= 1.0,
+        (-0.5..=1.0).contains(&ic_with),
         "IC with eras should be reasonable: got {:.4}",
         ic_with
     );
@@ -562,7 +562,7 @@ fn test_custom_validation_with_era_split() {
     // NOTE: For synthetic data with clear patterns, IC can be very high (0.9-1.0)
     // The key is that it's computed ONLY on validation eras (verified by debug output)
     assert!(
-        rank_ic >= -0.5 && rank_ic <= 1.0,
+        (-0.5..=1.0).contains(&rank_ic),
         "Rank IC should be reasonable for time-based split: got {:.4}",
         rank_ic
     );
@@ -585,7 +585,7 @@ fn test_custom_validation_with_era_split() {
     // This is the key test: if IC were computed on all data, it would be inflated
     // For synthetic data with clear patterns, IC can be very high (verified by debug output)
     assert!(
-        val_ic >= -0.5 && val_ic <= 1.0,
+        (-0.5..=1.0).contains(&val_ic),
         "Validation IC should be reasonable: got {:.4}",
         val_ic
     );
@@ -747,13 +747,13 @@ fn test_holdout_vs_conformal_with_rankic() {
     // Both should have reasonable IC values (not inflated)
     // For panel data with proper era-based splits, IC should be moderate
     assert!(
-        ic_holdout >= -0.5 && ic_holdout <= 1.0,
+        (-0.5..=1.0).contains(&ic_holdout),
         "Holdout IC should be reasonable: got {:.4}",
         ic_holdout
     );
 
     assert!(
-        ic_conformal >= -0.5 && ic_conformal <= 1.0,
+        (-0.5..=1.0).contains(&ic_conformal),
         "Conformal IC should be reasonable: got {:.4}",
         ic_conformal
     );
@@ -834,7 +834,7 @@ fn test_rankic_without_eras_uses_random_split() {
 
     // Should still compute IC (using global ranking, which is acceptable without eras)
     assert!(
-        ic >= -1.0 && ic <= 1.0,
+        (-1.0..=1.0).contains(&ic),
         "IC should be in valid range: got {:.4}",
         ic
     );

--- a/tests/loss.rs
+++ b/tests/loss.rs
@@ -12,7 +12,7 @@ use treeboost::loss::{sigmoid, LossFunction, MseLoss, MultiLabelFocalLoss, Multi
 #[test]
 fn test_multilabel_logloss_gradients() {
     let loss = MultiLabelLogLoss::new();
-    let num_outputs = 3;
+    let _num_outputs = 3;
 
     // Single sample with 3 labels
     // Target: [1, 0, 1]
@@ -132,7 +132,7 @@ fn test_multilabel_batch_gradients() {
 #[test]
 fn test_multilabel_initial_predictions() {
     let loss = MultiLabelLogLoss::new();
-    let num_rows = 4;
+    let _num_rows = 4;
     let num_outputs = 2;
 
     // Targets:
@@ -326,7 +326,7 @@ fn test_focal_loss_alpha_balancing() {
 #[test]
 fn test_focal_batch_gradients() {
     let focal = MultiLabelFocalLoss::new(2.0);
-    let num_rows = 2;
+    let _num_rows = 2;
     let num_outputs = 2;
 
     let targets = vec![1.0, 0.0, 0.0, 1.0];

--- a/tests/ltt_extrapolation.rs
+++ b/tests/ltt_extrapolation.rs
@@ -8,7 +8,6 @@
 
 mod common;
 
-use polars::prelude::*;
 use treeboost::{
     learner::{LinearConfig, TreeConfig},
     model::{AutoConfig, AutoModel, BoostingMode, TuningLevel, UniversalConfig},

--- a/tests/multiclass_multilabel.rs
+++ b/tests/multiclass_multilabel.rs
@@ -220,15 +220,15 @@ fn test_multiclass_predictions_sum_to_one() {
         max_deviation = max_deviation.max(deviation);
 
         assert!(
-            prob0 >= 0.0 && prob0 <= 1.0,
+            (0.0..=1.0).contains(&prob0),
             "Probability must be in [0, 1]"
         );
         assert!(
-            prob1 >= 0.0 && prob1 <= 1.0,
+            (0.0..=1.0).contains(&prob1),
             "Probability must be in [0, 1]"
         );
         assert!(
-            prob2 >= 0.0 && prob2 <= 1.0,
+            (0.0..=1.0).contains(&prob2),
             "Probability must be in [0, 1]"
         );
 
@@ -275,11 +275,11 @@ fn test_multiclass_with_imbalance() {
     let predictions: Vec<f32> = predictions_nested.into_iter().flatten().collect();
     let test_targets = test_binned.targets();
 
-    let mut class_correct = vec![0; 3];
-    let mut class_total = vec![0; 3];
+    let mut class_correct = [0; 3];
+    let mut class_total = [0; 3];
 
-    for i in 0..test_binned.num_rows() {
-        let true_class = test_targets[i] as usize;
+    for (i, &target) in test_targets.iter().enumerate() {
+        let true_class = target as usize;
         class_total[true_class] += 1;
 
         // Predicted class = argmax(probabilities)
@@ -439,17 +439,17 @@ fn test_multilabel_independent_predictions() -> std::result::Result<(), Box<dyn 
 
         // Each probability should be in [0, 1]
         assert!(
-            prob0 >= 0.0 && prob0 <= 1.0,
+            (0.0..=1.0).contains(&prob0),
             "Label 0 probability must be in [0, 1], got {}",
             prob0
         );
         assert!(
-            prob1 >= 0.0 && prob1 <= 1.0,
+            (0.0..=1.0).contains(&prob1),
             "Label 1 probability must be in [0, 1], got {}",
             prob1
         );
         assert!(
-            prob2 >= 0.0 && prob2 <= 1.0,
+            (0.0..=1.0).contains(&prob2),
             "Label 2 probability must be in [0, 1], got {}",
             prob2
         );

--- a/tests/multiclass_multilabel.rs
+++ b/tests/multiclass_multilabel.rs
@@ -52,7 +52,7 @@ fn dataframe_to_binned_multiclass(df: &DataFrame, target_col: &str) -> Result<Bi
             .unwrap()
             .f64()
             .unwrap()
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect();
 
@@ -86,7 +86,7 @@ fn dataframe_to_binned_multiclass(df: &DataFrame, target_col: &str) -> Result<Bi
         .unwrap()
         .i32()
         .unwrap()
-        .into_iter()
+        .iter()
         .map(|v| v.unwrap_or(0) as f32)
         .collect();
 
@@ -119,7 +119,7 @@ fn dataframe_to_binned_multilabel(df: &DataFrame, label_cols: &[String]) -> Resu
             .unwrap()
             .f64()
             .unwrap()
-            .into_iter()
+            .iter()
             .map(|v| v.unwrap_or(0.0))
             .collect();
 

--- a/tests/panel_data_detection.rs
+++ b/tests/panel_data_detection.rs
@@ -71,12 +71,12 @@ fn test_panel_data_detection_with_datapipeline() {
         assert_ne!(eras[3], eras[4]);
 
         // Verify first 4 rows are era 0
-        for i in 0..4 {
-            assert_eq!(eras[i], 0, "First 4 rows should be era 0");
+        for &era in &eras[0..4] {
+            assert_eq!(era, 0, "First 4 rows should be era 0");
         }
         // Verify next 4 rows are era 1
-        for i in 4..8 {
-            assert_eq!(eras[i], 1, "Rows 4-7 should be era 1");
+        for &era in &eras[4..8] {
+            assert_eq!(era, 1, "Rows 4-7 should be era 1");
         }
     }
 

--- a/tests/preprocessing.rs
+++ b/tests/preprocessing.rs
@@ -80,7 +80,7 @@ fn test_preprocessing_minmax_scaler() {
 
     // Verify all values in [0, 1]
     for &v in &transformed {
-        assert!(v >= 0.0 && v <= 1.0, "Value {} not in [0, 1]", v);
+        assert!((0.0..=1.0).contains(&v), "Value {} not in [0, 1]", v);
     }
 
     // Verify min and max values
@@ -164,7 +164,7 @@ fn test_preprocessing_frequency_encoder_workflow() {
     let categories = vec!["apple", "banana", "apple", "cherry", "apple", "banana"];
 
     let mut encoder = FrequencyEncoder::new().with_normalize(true);
-    let _ = encoder.fit(&categories);
+    encoder.fit(&categories);
 
     assert!(encoder.is_fitted());
     assert_eq!(encoder.num_categories(), 3);
@@ -189,7 +189,7 @@ fn test_preprocessing_label_encoder_roundtrip() {
     let categories = vec!["red", "green", "blue", "red", "green"];
 
     let mut encoder = LabelEncoder::new();
-    let _ = encoder.fit(&categories);
+    encoder.fit(&categories);
 
     let labels = encoder
         .transform(&categories)

--- a/tests/rf_robustness.rs
+++ b/tests/rf_robustness.rs
@@ -41,7 +41,7 @@ fn generate_noise_dataset(num_rows: usize) -> BinnedDataset {
     for i in 0..num_features {
         let dist = Normal::new(0.0f32, 1.0f32).unwrap();
 
-        for r in 0..num_rows {
+        for sig in signal.iter_mut() {
             // Sample value and bin it to u8 range [0, 255]
             let val = dist.sample(&mut rng);
             let binned = ((val + 3.0).clamp(0.0, 6.0) / 6.0 * 255.0) as u8;
@@ -50,7 +50,7 @@ fn generate_noise_dataset(num_rows: usize) -> BinnedDataset {
             // First 10 features contribute to signal (with decaying weights)
             if i < num_informative {
                 let weight = (10 - i) as f32;
-                signal[r] += val * weight;
+                *sig += val * weight;
             }
         }
     }
@@ -98,8 +98,8 @@ fn extract_subset(dataset: &BinnedDataset, start: usize, end: usize) -> BinnedDa
     let mut features = Vec::with_capacity(n_rows * n_features);
     for f in 0..n_features {
         let col = dataset.feature_column(f);
-        for r in start..end {
-            features.push(col[r]);
+        for &val in &col[start..end] {
+            features.push(val);
         }
     }
 

--- a/tests/robust_loss.rs
+++ b/tests/robust_loss.rs
@@ -121,8 +121,7 @@ fn dataframe_to_binned_with_stats(
     // Create feature info
     let feature_info: Vec<treeboost::dataset::FeatureInfo> = feature_cols
         .iter()
-        .enumerate()
-        .map(|(_i, &name)| treeboost::dataset::FeatureInfo {
+        .map(|&name| treeboost::dataset::FeatureInfo {
             name: name.to_string(),
             feature_type: treeboost::dataset::FeatureType::Numeric,
             num_bins: 255,
@@ -518,6 +517,8 @@ fn calculate_rmse_f32(predictions: &[f32], targets: &[f32]) -> f32 {
 }
 
 /// Calculate Root Mean Squared Error (f64 version)
+// reason: kept as a test helper alongside the f32 variant; not used by every test.
+#[allow(dead_code)]
 fn calculate_rmse(predictions: &[f64], targets: &[f64]) -> f64 {
     assert_eq!(
         predictions.len(),

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -2,7 +2,7 @@
 //!
 //! Tree Node Vector Storage (2D Multi-Label Support)
 
-use treeboost::tree::{VectorNode, VectorNodeType, VectorTree};
+use treeboost::tree::{VectorNode, VectorTree};
 
 /// Test vector node creation and accessors
 #[test]

--- a/tests/universal_multilabel.rs
+++ b/tests/universal_multilabel.rs
@@ -124,7 +124,7 @@ fn test_ltt_multilabel_prediction_shape() -> Result<(), Box<dyn std::error::Erro
     for row in &proba {
         for &p in row {
             assert!(
-                p >= 0.0 && p <= 1.0,
+                (0.0..=1.0).contains(&p),
                 "Probability should be in [0, 1], got {}",
                 p
             );
@@ -165,8 +165,8 @@ fn test_ltt_multilabel_correctness() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // GBDT should achieve reasonable accuracy
-    for k in 0..num_outputs {
-        let accuracy = gbdt_correct_per_label[k] as f64 / num_rows as f64;
+    for (k, &correct) in gbdt_correct_per_label.iter().enumerate() {
+        let accuracy = correct as f64 / num_rows as f64;
         assert!(
             accuracy > 0.5,
             "GBDT Label {} accuracy {:.2} should be better than random",
@@ -201,8 +201,8 @@ fn test_ltt_multilabel_correctness() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // LTT should also achieve reasonable accuracy (at least as good as GBDT)
-    for k in 0..num_outputs {
-        let accuracy = correct_per_label[k] as f64 / num_rows as f64;
+    for (k, &correct) in correct_per_label.iter().enumerate() {
+        let accuracy = correct as f64 / num_rows as f64;
         assert!(
             accuracy > 0.5,
             "LTT Label {} accuracy {:.2} should be better than random",


### PR DESCRIPTION
Hi there! First off, thanks for the great work on treeboost!

## Summary
I needed polars 0.53 for a downstream project and ran into the version constraint, so I went ahead and bumped polars from 0.51 to 0.53 along with all the other dependencies. Hope this is helpful!

- Upgrades polars from 0.51 to 0.53, addressing all breaking API changes
- Bumps all other dependencies to their latest compatible versions
- Fixes API breakages across 27 files including dataset I/O, feature engineering, model pipeline, preprocessing, serialization, and autotuner modules
- Updates examples and tests to match the new APIs

## Changed Areas
- **Dataset I/O & Pipeline:** `loader.rs`, `pipeline.rs`, `dataframe.rs`
- **Feature Engineering:** `crosssectional.rs`, `dataframe.rs`, `smart.rs`
- **Model Pipeline & Training:** `steps.rs`, `predictor.rs`, `incremental.rs`, `training.rs`
- **Preprocessing:** `dataframe.rs`, `polars_ext.rs`, `smart.rs`
- **Serialization:** `bincode_io.rs`, `trb.rs`
- **Autotuner:** `execution.rs`, `grid.rs`, `types.rs`
- **Analysis:** `analyzer.rs`, `profiler.rs`
- **Tests & Examples:** `automl_ltt.rs`, `automl_multilabel.rs`, `automl_profile.rs`, `multilabel.rs`